### PR TITLE
Avoid synchronous loading on client if options.ssr is false

### DIFF
--- a/examples/server-side-rendering/src/client/App.js
+++ b/examples/server-side-rendering/src/client/App.js
@@ -12,6 +12,16 @@ const X = loadable(props => import(`./letters/${props.letter}`))
 const Sub = loadable(props => import(`./letters/${props.letter}/file`))
 const RootSub = loadable(props => import(`./${props.letter}/file`))
 
+// Load the 'G' component twice: once in SSR and once fully client-side
+const GClient = loadable(() => import('./letters/G'), {
+  ssr: false,
+  fallback: <span className="loading-state">ssr: false - Loading...</span>,
+})
+const GServer = loadable(() => import('./letters/G'), {
+  ssr: true,
+  fallback: <span className="loading-state">ssr: true - Loading...</span>,
+})
+
 // We keep some references to prevent uglify remove
 A.C = C
 A.D = D
@@ -29,6 +39,10 @@ const App = () => (
     <X letter="F" />
     <br />
     <E />
+    <br />
+    <GClient prefix="ssr: false" />
+    <br />
+    <GServer prefix="ssr: true" />
     <br />
     <Sub letter="Z" />
     <br />

--- a/examples/server-side-rendering/src/client/letters/G.js
+++ b/examples/server-side-rendering/src/client/letters/G.js
@@ -1,0 +1,4 @@
+import React from 'react'
+const G = ({prefix}) => <span className="my-cool-class">{prefix} - G</span>
+
+export default G

--- a/examples/server-side-rendering/src/client/letters/G.js
+++ b/examples/server-side-rendering/src/client/letters/G.js
@@ -1,4 +1,11 @@
 import React from 'react'
-const G = ({prefix}) => <span className="my-cool-class">{prefix} - G</span>
+
+const G = ({prefix}) => (
+  <span className="my-cool-class">
+    {prefix}
+    {' '}
+    - G
+  </span>
+)
 
 export default G

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -80,7 +80,9 @@ function createLoadable({ resolve = identity, render, onLoad }) {
 
         // Client-side with `isReady` method present (SSR probably)
         // If module is already loaded, we use a synchronous loading
-        if (ctor.isReady && ctor.isReady(props)) {
+        // Only perform this synchronous loading if the component has not
+        // been marked with no SSR, else we risk hydration mismatches
+        if (options.ssr !== false && ctor.isReady && ctor.isReady(props)) {
           this.loadSync()
         }
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Fixes #345. See description there for more details. 

**tl;dr**: in cases where `ssr: false` is set, this PR fixes the way we render the component on the client to match what the server is doing, avoiding problematic SSR hydration mismatches (https://reactjs.org/docs/react-dom.html#hydrate).

## Test plan

Updated the SSR example to add a new letter, `G`, which is rendered on the page with both `ssr: true` and `ssr: false`. Without the change applied, the DOM looks like this (incorrect):

![image](https://user-images.githubusercontent.com/643295/58054635-03812800-7b10-11e9-9bbe-85c9ab5bc120.png)

with the change applied, the DOM now correctly looks like this:

![image](https://user-images.githubusercontent.com/643295/58054667-1ac01580-7b10-11e9-975d-7b377241f59d.png)

As mentioned in #345, I can't see any existing integration tests for SSR: if I missed some or if you think it's worth adding some, I'm happy to help set that up. Thanks in advance for reviewing!
