### PR TITLE
Add support for passing multiple ChunkExtractor instances to ChunkExtractorManager

### DIFF
--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/loadable.cjs.js": {
-    "bundled": 12664,
-    "minified": 6090,
-    "gzipped": 2184
+    "bundled": 12853,
+    "minified": 6200,
+    "gzipped": 2223
   },
   "dist/loadable.esm.js": {
-    "bundled": 12281,
-    "minified": 5781,
-    "gzipped": 2119,
+    "bundled": 12470,
+    "minified": 5891,
+    "gzipped": 2155,
     "treeshaked": {
       "rollup": {
         "code": 259,
         "import_statements": 259
       },
       "webpack": {
-        "code": 5054
+        "code": 5158
       }
     }
   }

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -74,7 +74,13 @@ function createLoadable({ resolve = identity, render, onLoad }) {
           // So we can require now the module synchronously
           this.loadSync()
 
-          props.__chunkExtractor.addChunk(ctor.chunkName(props))
+          const chunkExtractors = Array.isArray(props.__chunkExtractor)
+            ? props.__chunkExtractor
+            : [props.__chunkExtractor]
+          chunkExtractors.forEach(extractor =>
+            extractor.addChunk(ctor.chunkName(props)),
+          )
+
           return
         }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I wanted to be able to populate multiple `loadableState`s so I could do a modern/legacy bundle split while having the appropriate scripts included in the server rendered markup. Current the only way to do this is to render twice with separate `<ChunkExtractorManager>`s, as they share a context multiple `<ChunkExtractorManager>`s with different `extractor`s does not work.


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

With this PR comes support for passing multiple `ChunkExtractor` instances to `<ChunkExtractorManager>`: 


```js
const modernLoadableState = new ChunkExtractor({
  publicPath,
  namespace: "modern",
  statsFile: path.resolve(
    process.env.RAZZLE_ASSETS_MANIFEST.replace("assets.json", "loadable-stats.modern.json"),
  ),
  entrypoints: "client",
});
const legacyLoadableState = new ChunkExtractor({
  publicPath,
  namespace: "legacy",
  statsFile: path.resolve(
    process.env.RAZZLE_ASSETS_MANIFEST.replace("assets.json", "loadable-stats.legacy.json"),
  ),
  entrypoints: "client",
});
try {
  await getDataFromTree(
    <ChunkExtractorManager extractor={[modernLoadableState, legacyLoadableState]}>
      {components}
    </ChunkExtractorManager>,
  );
} finally {
  modernScriptElements = modernLoadableState.getScriptElements({ type: "module" });
  legacyScriptElements = legacyLoadableState.getScriptElements({ noModule: true });
}
```

I decided to implement this in a way that I would only touch very little code; with an edit in `createLoadable`. But we could save a tiny bit of client bundle size by moving logic into ChunkExtractorManager.
