### PR TITLE
Add support for named exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "bundlesize": [
     {
       "path": "./packages/component/dist/loadable.min.js",
-      "maxSize": "2.5 kB"
+      "maxSize": "3.5 kB"
     },
     {
       "path": "./packages/component/dist/loadable.esm.js",
-      "maxSize": "3.5 kB"
+      "maxSize": "4.5 kB"
     }
   ],
   "scripts": {

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.7",
-    "hoist-non-react-statics": "^3.3.1"
+    "hoist-non-react-statics": "^3.3.1",
+    "react-is": "^16.12.0"
   }
 }

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-use-before-define, react/no-multi-comp, no-underscore-dangle */
 import React from 'react'
+import * as ReactIs from 'react-is'
+import hoistNonReactStatics from 'hoist-non-react-statics'
 import { invariant } from './util'
 import Context from './Context'
 
@@ -19,7 +21,7 @@ const withChunkExtractor = Component => props => (
 
 const identity = v => v
 
-function createLoadable({ resolve = identity, render, onLoad }) {
+function createLoadable({ defaultResolveComponent = identity, render, onLoad }) {
   function loadable(loadableConstructor, options = {}) {
     const ctor = resolveConstructor(loadableConstructor)
     const cache = {}
@@ -31,6 +33,19 @@ function createLoadable({ resolve = identity, render, onLoad }) {
         return ctor.resolve(props)
       }
       return null
+    }
+
+    function resolve(module, props, Loadable) {
+      const Component = options.resolveComponent
+        ? options.resolveComponent(module, props)
+        : defaultResolveComponent(module)
+      if (options.resolveComponent && !ReactIs.isValidElementType(Component)) {
+        throw new Error(`resolveComponent returned something that is not a React component!`)
+      }
+      hoistNonReactStatics(Loadable, Component, {
+        preload: true,
+      })
+      return Component;
     }
 
     class InnerLoadable extends React.Component {
@@ -128,7 +143,7 @@ function createLoadable({ resolve = identity, render, onLoad }) {
 
         try {
           const loadedModule = ctor.requireSync(this.props)
-          const result = resolve(loadedModule, { Loadable })
+          const result = resolve(loadedModule, this.props, Loadable)
           this.state.result = result
           this.state.loading = false
         } catch (error) {
@@ -154,13 +169,13 @@ function createLoadable({ resolve = identity, render, onLoad }) {
           this.promise = ctor
             .requireAsync(props)
             .then(loadedModule => {
-              const result = resolve(loadedModule, { Loadable })
+              const result = resolve(loadedModule, this.props, Loadable)
               if (options.suspense) {
                 this.setCache(result)
               }
               this.safeSetState(
                 {
-                  result: resolve(loadedModule, { Loadable }),
+                  result: resolve(loadedModule, this.props, Loadable),
                   loading: false,
                 },
                 () => this.triggerOnLoad(),

--- a/packages/component/src/loadable.js
+++ b/packages/component/src/loadable.js
@@ -1,10 +1,10 @@
 /* eslint-disable no-use-before-define, react/no-multi-comp */
 import React from 'react'
 import createLoadable from './createLoadable'
-import { resolveComponent } from './resolvers'
+import { defaultResolveComponent } from './resolvers'
 
 export const { loadable, lazy } = createLoadable({
-  resolve: resolveComponent,
+  defaultResolveComponent,
   render({ result: Component, props }) {
     return <Component {...props} />
   },

--- a/packages/component/src/loadable.test.js
+++ b/packages/component/src/loadable.test.js
@@ -90,12 +90,28 @@ describe('#loadable', () => {
     expect(load).toHaveBeenCalledTimes(2)
   })
 
-  it('supports non-default export', async () => {
+  it('supports commonjs default export', async () => {
     const load = createLoadFunction()
     const Component = loadable(load)
     const { container } = render(<Component />)
     load.resolve(() => 'loaded')
     await wait(() => expect(container).toHaveTextContent('loaded'))
+  })
+
+  it('supports non-default export via resolveComponent', async () => {
+    const load = createLoadFunction()
+    const importedModule = { exported: () => 'loaded'};
+    const resolveComponent = jest.fn(({ exported: component }) => component);
+    const Component = loadable(load, {
+      resolveComponent,
+    })
+    const { container } = render(<Component someProp="123" />)
+    load.resolve(importedModule)
+    await wait(() => expect(container).toHaveTextContent('loaded'))
+    expect(resolveComponent).toHaveBeenCalledWith(
+      importedModule,
+      { someProp: '123', __chunkExtractor: undefined, forwardedRef: null },
+    )
   })
 
   it('forwards props', async () => {

--- a/packages/component/src/resolvers.js
+++ b/packages/component/src/resolvers.js
@@ -1,12 +1,6 @@
-import hoistNonReactStatics from 'hoist-non-react-statics'
-
-export function resolveComponent(loadedModule, { Loadable }) {
+export function defaultResolveComponent(loadedModule) {
   // eslint-disable-next-line no-underscore-dangle
-  const Component = loadedModule.__esModule
-    ? loadedModule.default
-    : loadedModule.default || loadedModule
-  hoistNonReactStatics(Loadable, Component, {
-    preload: true,
-  })
-  return Component
+ return loadedModule.__esModule
+  ? loadedModule.default
+  : loadedModule.default || loadedModule
 }

--- a/website/src/pages/docs/api-loadable-component.mdx
+++ b/website/src/pages/docs/api-loadable-component.mdx
@@ -10,19 +10,55 @@ order: 10
 
 Create a loadable component.
 
-| Arguments          | Description                                                          |
-| ------------------ | -------------------------------------------------------------------- |
-| `loadFn`           | The function call to load the component.                             |
-| `options`          | Optional options.                                                    |
-| `options.fallback` | Fallback displayed during the loading.                               |
-| `options.ssr`      | If `false`, it will not be processed server-side. Default to `true`. |
-| `options.cacheKey` | Cache key function (see [dynamic import](/docs/dynamic-import/))      |
+| Arguments                  | Description                                                          |
+| -------------------------- | -------------------------------------------------------------------- |
+| `loadFn`                   | The function call to load the component.                             |
+| `options`                  | Optional options.                                                    |
+| `options.resolveComponent` | Function to resolve the imported component from the imported module. |
+| `options.fallback`         | Fallback displayed during the loading.                               |
+| `options.ssr`              | If `false`, it will not be processed server-side. Default to `true`. |
+| `options.cacheKey`         | Cache key function (see [dynamic import](/docs/dynamic-import/))     |
 
 ```js
 import loadable from '@loadable/component'
 
 const OtherComponent = loadable(() => import('./OtherComponent'))
 ```
+
+### `options.resolveComponent`
+This is a function that receives the imported module (what the `import()` call resolves to) and the props, and returns the component.
+
+The default value assumes that the component is exported as a default export.
+It can be customized to make a loadable component where the imported component is not the default export, or even where a different export is chosen depending on the props.
+For example:
+
+```js
+// components.js
+
+export const Apple = () => 'Apple!'
+export const Orange = () => 'Orange!'
+```
+
+```js
+// loadable.js
+
+const LoadableApple = loadable(() => import('./components'), {
+  resolveComponent: (components) => components.Apple,
+})
+
+const LoadableOrange = loadable(() => import('./components'), {
+  resolveComponent: (components) => components.Orange,
+})
+
+const LoadableFruit = loadable(() => import('./components'), {
+  resolveComponent: (components, props) => components[props.fruit],
+})
+
+```
+
+**Note:** The default `resolveComponent` breaks Typescript type inference due to CommonJS compatibility.
+To avoid this, you can specify `resolveComponent` as `(imported) => imported.default`.
+This requires that the imported components have ES6/Harmony exports.
 
 ## lazy
 
@@ -89,13 +125,14 @@ OtherComponent.load().then(() => {
 
 Create a loadable library.
 
-| Arguments          | Description                                                          |
-| ------------------ | -------------------------------------------------------------------- |
-| `loadFn`           | The function call to load the component.                             |
-| `options`          | Optional options.                                                    |
-| `options.fallback` | Fallback displayed during the loading.                               |
-| `options.ssr`      | If `false`, it will not be processed server-side. Default to `true`. |
-| `options.cacheKey` | Cache key function (see [dynamic import](/docs/dynamic-import))      |
+| Arguments                  | Description                                                          |
+| -------------------------- | -------------------------------------------------------------------- |
+| `loadFn`                   | The function call to load the component.                             |
+| `options`                  | Optional options.                                                    |
+| `options.resolveComponent` | Function to resolve the imported component from the imported module. |
+| `options.fallback`         | Fallback displayed during the loading.                               |
+| `options.ssr`              | If `false`, it will not be processed server-side. Default to `true`. |
+| `options.cacheKey`         | Cache key function (see [dynamic import](/docs/dynamic-import))      |
 
 ```js
 import loadable from '@loadable/component'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7938,7 +7938,7 @@ react-dom@^16.12.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

See https://github.com/gregberge/loadable-components/issues/245

Currently to create a loadable component, the module that is asynchronously loaded must export the component as the default export (or be a commonjs module exporting the component as `module.exports`). This is problematic/limiting because:
- There are good reasons to avoid default exports (prevents grepping a codebase to find usages of an export, prevents import auto completion from working in most/all IDEs)
- It is not possible to make [multiple loadable components using the same split point](https://github.com/gregberge/loadable-components/issues/245#issuecomment-564467163) (instead one must hard code chunk names with webpack "magic comments" - not a standard feature)

## Detailed choices

See https://github.com/gregberge/loadable-components/issues/245 for preliminary discussion of the API
- `loadable` and `loadable.lib` still accept the import creator as the first argument. This means that for the common/simple case of `loadable(() => import('./xyz'))`, there is no breaking change, instead options are added.
- `resolveComponent` is optional and defaults to the existing behaviour. Again, no breaking change, but typescript type inference (for the props of the loadable component) does not work unless it is specified. I think this is a consequence of the CommonJS compatibility.

## Benefits

### Ability to use named exports (including on the server side)
Use `resolveComponent` to select the export

### Ability to create multiple loadable components from a single split point
```typescript
// split.tsx
import React from 'react';

type Props1 = {
  prop1: string;
};

export const Component1 ({ prop1 }: Props1): JSX.Element => (
  <span>{prop1}</span>
);

type Props2 = {
  prop2: string;
};

export const Component2 ({ prop2 }: Props2): JSX.Element => (
  <span>{prop2}</span>
);
```
```typescript
import loadable from '@loadable/component';

const LoadableComponent1 = loadable(() => import('./testComponent'), {
  resolveComponent: (mod) => mod.Component1,
});

const LoadableComponent2 = loadable(() => import('./testComponent'), {
  resolveComponent: (mod) => mod.Component2,
});
```

####  `resloveComponent` has access to props
```typescript
import loadable from '@loadable/component';
const DynamicLoadableComponent = loadable(() => import('./xyz'), {
  resolveComponent: (mod, props) => mod[props.export],
});
```

### Typescript type inference
When using `resolveComponent`, typescript is able to infer the type of the Props of the loadable component (previously they were always `unknown`). I think the default type/implementation of `resolveComponent` breaks type inference somehow by supporting commonjs default exports.

#### Before
```typescript
// testComponent.tsx
import React from 'react';

type TestProps = {
  prop1: string;
};

export default ({ prop1 }: TestProps): JSX.Element => (
  <span>{prop1}</span>
);
```
```typescript
// loadableTestComponent.ts
import loadable from '@loadable/component';

// Inferred type: `LoadableComponent<unknown>`  :(
const LoadableComponent = loadable(() => import('./testComponent'));
```

#### After
```typescript
// testComponent.tsx
import React from 'react';

type TestProps = {
  prop1: string;
};

export default ({ prop1 }: TestProps): JSX.Element => (
  <span>{prop1}</span>
);
```
```typescript
// loadableTestComponent.ts
import loadable from '@loadable/component';

// Inferred type: `LoadableComponent<TestProps>` :)
const LoadableComponent = loadable(() => import('./testComponent'), {
  resolveComponent: (mod) => mod.default,
});
```

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Existing tests have been changed where necessary and new tests have been added for new functionality
