### PR TITLE
perf: avoid calling stats.toJson if possible

### DIFF
--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -75,7 +75,9 @@ class LoadablePlugin {
     // Add a custom output.jsonpFunction: __LOADABLE_LOADED_CHUNKS__
     compiler.options.output.jsonpFunction = '__LOADABLE_LOADED_CHUNKS__'
 
-    compiler.hooks.emit.tapAsync('@loadable/webpack-plugin', this.handleEmit)
+    if (this.opts.outputAsset || this.opts.writeToDisk) {
+      compiler.hooks.emit.tapAsync('@loadable/webpack-plugin', this.handleEmit)
+    }
   }
 }
 

--- a/website/src/pages/docs/server-side-rendering.mdx
+++ b/website/src/pages/docs/server-side-rendering.mdx
@@ -244,3 +244,25 @@ const extractor = new ChunkExtractor({
   entrypoints: ['client'] // array of webpack entries (default: ['main'])
 })
 ```
+
+## Using your own stats file
+
+By default, the webpack plugin adds an asset to the webpack build called `loadable-stats.json`. This contains the result of running webpack's [`stats.toJson()`](https://webpack.js.org/api/node/#statstojsonoptions) with the following options:
+
+```js
+{
+  hash: true,
+  publicPath: true,
+  assets: true,
+  chunks: false,
+  modules: false,
+  source: false,
+  errorDetails: false,
+  timings: false,
+}
+```
+
+`stats.toJson()` is an expensive operation, and it can significantly slow down webpack watching recompiles.
+If you already have a webpack stats file in your build that includes the necessary options, you may choose to use your existing stats object instead of creating a new one. You can do this as follows:
+ - pass your existing stats object into [`ChunkExtractor`](/docs/api-loadable-server/#chunkextractor) via the `stats` option
+ - disable both the `outputAsset` and `writeToDisk` options in the [webpack plugin](/docs/api-loadable-webpack-plugin/#loadableplugin) to prevent it from calling `stats.toJson()`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Webpack `stats.toJson` is an expensive operation for large builds, and the loadable-components webpack plugin runs it each emit (so it slows down the watching recompile). Often there are many reasons besides loadable-components to have a stats asset in a build, and large speed savings can be made by combining them into one.

This change avoids running `stats.toJson` (or adding the emit hook at all) if both `outputAsset` and `writeToDisk` are false, in which case the returned value is unused.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
