### PR TITLE
Separate delay/timeout/sideload functionality from loadFn

### DIFF
--- a/packages/babel-plugin/src/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin/src/__snapshots__/index.test.js.snap
@@ -580,62 +580,6 @@ exports[`plugin loadable.lib should be transpiled too 1`] = `
 });"
 `;
 
-exports[`plugin simple import in a complex promise should work 1`] = `
-"loadable({
-  resolved: {},
-
-  chunkName() {
-    return \\"ModA\\";
-  },
-
-  isReady(props) {
-    const key = this.resolve(props);
-
-    if (this.resolved[key] === false) {
-      return false;
-    }
-
-    if (typeof __webpack_modules__ !== 'undefined') {
-      return !!__webpack_modules__[key];
-    }
-
-    return false;
-  },
-
-  importAsync: () => timeout(import(
-  /* webpackChunkName: \\"ModA\\" */
-  './ModA'), 2000),
-
-  requireAsync(props) {
-    const key = this.resolve(props);
-    this.resolved[key] = false;
-    return this.importAsync(props).then(resolved => {
-      this.resolved[key] = true;
-      return resolved;
-    });
-  },
-
-  requireSync(props) {
-    const id = this.resolve(props);
-
-    if (typeof __webpack_require__ !== 'undefined') {
-      return __webpack_require__(id);
-    }
-
-    return eval('module.require')(id);
-  },
-
-  resolve() {
-    if (require.resolveWeak) {
-      return require.resolveWeak(\\"./ModA\\");
-    }
-
-    return eval('require.resolve')(\\"./ModA\\");
-  }
-
-});"
-`;
-
 exports[`plugin simple import should transform path into "chunk-friendly" name 1`] = `
 "loadable({
   resolved: {},
@@ -940,6 +884,120 @@ exports[`plugin simple import with "webpackChunkName" comment should use it even
 
   importAsync: () => import(
   /* webpackPrefetch: true, webpackChunkName: \\"ChunkA\\" */
+  './ModA'),
+
+  requireAsync(props) {
+    const key = this.resolve(props);
+    this.resolved[key] = false;
+    return this.importAsync(props).then(resolved => {
+      this.resolved[key] = true;
+      return resolved;
+    });
+  },
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\\"./ModA\\");
+    }
+
+    return eval('require.resolve')(\\"./ModA\\");
+  }
+
+});"
+`;
+
+exports[`plugin simple import with arrow function with body 1`] = `
+"loadable({
+  resolved: {},
+
+  chunkName() {
+    return \\"ModA\\";
+  },
+
+  isReady(props) {
+    const key = this.resolve(props);
+
+    if (this.resolved[key] === false) {
+      return false;
+    }
+
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[key];
+    }
+
+    return false;
+  },
+
+  importAsync: () => {
+    return import(
+    /* webpackChunkName: \\"ModA\\" */
+    './ModA');
+  },
+
+  requireAsync(props) {
+    const key = this.resolve(props);
+    this.resolved[key] = false;
+    return this.importAsync(props).then(resolved => {
+      this.resolved[key] = true;
+      return resolved;
+    });
+  },
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\\"./ModA\\");
+    }
+
+    return eval('require.resolve')(\\"./ModA\\");
+  }
+
+});"
+`;
+
+exports[`plugin simple import with async arrow function 1`] = `
+"loadable({
+  resolved: {},
+
+  chunkName() {
+    return \\"ModA\\";
+  },
+
+  isReady(props) {
+    const key = this.resolve(props);
+
+    if (this.resolved[key] === false) {
+      return false;
+    }
+
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[key];
+    }
+
+    return false;
+  },
+
+  importAsync: async () => import(
+  /* webpackChunkName: \\"ModA\\" */
   './ModA'),
 
   requireAsync(props) {

--- a/packages/babel-plugin/src/index.test.js
+++ b/packages/babel-plugin/src/index.test.js
@@ -73,13 +73,39 @@ describe('plugin', () => {
       })
     })
 
-    describe('in a complex promise', () => {
-      it('should work', () => {
-        const result = testPlugin(`
-          loadable(() => timeout(import('./ModA'), 2000))
-        `)
+    it('with arrow function with body', () => {
+      const result = testPlugin(`
+        loadable(() => { return import('./ModA') })
+      `)
 
-        expect(result).toMatchSnapshot()
+      expect(result).toMatchSnapshot()
+    })
+
+    it('with async arrow function', () => {
+      const result = testPlugin(`
+        loadable(async () => import('./ModA'))
+      `)
+
+      expect(result).toMatchSnapshot()
+    })
+  })
+
+  describe('reject wrapping of import', () => {
+    describe('in a wrapped promise', () => {
+      it('should fail', () => {
+        expect(() => testPlugin(`
+          loadable(() => timeout(import('./ModA'), 2000))
+        `)).toThrow()
+      })
+    })
+
+    describe('returning an await statement', () => {
+      it('should fail', () => {
+        expect(() => testPlugin(`
+          loadable(async () => {
+            return await import('./ModA');
+          })
+        `)).toThrow()
       })
     })
   })

--- a/packages/component/src/loadable.test.js
+++ b/packages/component/src/loadable.test.js
@@ -17,6 +17,10 @@ function createLoadFunction() {
   return fn
 }
 
+function flushPromises() {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
 class Catch extends React.Component {
   state = { error: false }
 
@@ -73,7 +77,8 @@ describe('#loadable', () => {
     const { container } = render(<Component />)
     expect(container).toBeEmpty()
     load.resolve({ default: () => 'loaded' })
-    await wait(() => expect(container).toHaveTextContent('loaded'))
+    await flushPromises()
+    expect(container).toHaveTextContent('loaded')
   })
 
   it('supports preload', async () => {
@@ -86,7 +91,8 @@ describe('#loadable', () => {
     const { container } = render(<Component />)
     expect(container).toBeEmpty()
     load.resolve({ default: () => 'loaded' })
-    await wait(() => expect(container).toHaveTextContent('loaded'))
+    await flushPromises()
+    expect(container).toHaveTextContent('loaded')
     expect(load).toHaveBeenCalledTimes(2)
   })
 
@@ -95,7 +101,8 @@ describe('#loadable', () => {
     const Component = loadable(load)
     const { container } = render(<Component />)
     load.resolve(() => 'loaded')
-    await wait(() => expect(container).toHaveTextContent('loaded'))
+    await flushPromises()
+    expect(container).toHaveTextContent('loaded')
   })
 
   it('forwards props', async () => {
@@ -103,7 +110,8 @@ describe('#loadable', () => {
     const Component = loadable(load)
     const { container } = render(<Component name="James Bond" />)
     load.resolve({ default: ({ name }) => name })
-    await wait(() => expect(container).toHaveTextContent('James Bond'))
+    await flushPromises()
+    expect(container).toHaveTextContent('James Bond')
   })
 
   it('should update component if props change', async () => {
@@ -111,9 +119,11 @@ describe('#loadable', () => {
     const Component = loadable(load)
     const { container } = render(<Component value="first" />)
     load.resolve({ default: ({ value }) => value })
-    await wait(() => expect(container).toHaveTextContent('first'))
+    await flushPromises()
+    expect(container).toHaveTextContent('first')
     render(<Component value="second" />, { container })
-    await wait(() => expect(container).toHaveTextContent('second'))
+    await flushPromises()
+    expect(container).toHaveTextContent('second')
     expect(load).toHaveBeenCalledTimes(1)
   })
 
@@ -122,10 +132,12 @@ describe('#loadable', () => {
     const Component = loadable(load, { cacheKey: ({ value }) => value })
     const { container } = render(<Component value="first" />)
     load.resolve({ default: ({ value }) => value })
-    await wait(() => expect(container).toHaveTextContent('first'))
+    await flushPromises()
+    expect(container).toHaveTextContent('first')
     expect(load).toHaveBeenCalledTimes(1)
     render(<Component value="second" />, { container })
-    await wait(() => expect(container).toHaveTextContent('second'))
+    await flushPromises()
+    expect(container).toHaveTextContent('second')
     expect(load).toHaveBeenCalledTimes(2)
   })
 
@@ -137,10 +149,12 @@ describe('#loadable', () => {
     })
     const { container } = render(<Component value="first" />)
     load.resolve({ default: ({ value }) => value })
-    await wait(() => expect(container).toHaveTextContent('first'))
+    await flushPromises()
+    expect(container).toHaveTextContent('first')
     expect(load).toHaveBeenCalledTimes(1)
     render(<Component value="second" />, { container })
-    await wait(() => expect(container).toHaveTextContent('second'))
+    await flushPromises()
+    expect(container).toHaveTextContent('second')
     expect(load).toHaveBeenCalledTimes(2)
   })
 
@@ -154,17 +168,20 @@ describe('#loadable', () => {
     })
     const Component = loadable(load, { cacheKey: ({ name }) => name })
     const { container } = render(<Component name="A" id={0} />)
-    await wait(() => expect(container).toHaveTextContent('A-0'))
+    await flushPromises()
+    expect(container).toHaveTextContent('A-0')
     expect(load).toHaveBeenCalledTimes(1)
     expect(load).toHaveBeenCalledWith({ name: 'A', id: 0 })
     expect(A).toHaveBeenCalledTimes(1)
     expect(A).toHaveBeenCalledWith({ name: 'A', id: 0 }, {})
     render(<Component name="A" id={1} />, { container })
-    await wait(() => expect(container).toHaveTextContent('A-1'))
+    await flushPromises()
+    expect(container).toHaveTextContent('A-1')
     expect(A).toHaveBeenCalledTimes(2)
     expect(A).toHaveBeenCalledWith({ name: 'A', id: 1 }, {})
     render(<Component name="B" id={2} />, { container })
-    await wait(() => expect(container).toHaveTextContent('B-2'))
+    await flushPromises()
+    expect(container).toHaveTextContent('B-2')
     expect(load).toHaveBeenCalledTimes(2)
     expect(load).toHaveBeenCalledWith({ name: 'B', id: 2 })
     expect(B).toHaveBeenCalledTimes(1)
@@ -182,7 +199,8 @@ describe('#loadable', () => {
     load.resolve({
       default: React.forwardRef((props, fref) => <div {...props} ref={fref} />),
     })
-    await wait(() => expect(ref.current.tagName).toBe('DIV'))
+    await flushPromises()
+    expect(ref.current.tagName).toBe('DIV')
   })
 
   it('throws when an error occurs', async () => {
@@ -195,7 +213,8 @@ describe('#loadable', () => {
     )
     expect(container).toBeEmpty()
     load.reject(new Error('boom'))
-    await wait(() => expect(container).toHaveTextContent('error'))
+    await flushPromises()
+    expect(container).toHaveTextContent('error')
   })
 })
 
@@ -223,7 +242,8 @@ describe('#loadable.lib', () => {
     expect(container).toBeEmpty()
     const library = { it: 'is', a: 'lib' }
     load.resolve(library)
-    await wait(() => expect(container).toHaveTextContent('loaded'))
+    await flushPromises()
+    expect(container).toHaveTextContent('loaded')
     expect(renderFn).toHaveBeenCalledWith(library)
   })
 })

--- a/website/src/pages/docs/api-loadable-component.mdx
+++ b/website/src/pages/docs/api-loadable-component.mdx
@@ -10,19 +10,33 @@ order: 10
 
 Create a loadable component.
 
-| Arguments          | Description                                                          |
-| ------------------ | -------------------------------------------------------------------- |
-| `loadFn`           | The function call to load the component.                             |
-| `options`          | Optional options.                                                    |
-| `options.fallback` | Fallback displayed during the loading.                               |
-| `options.ssr`      | If `false`, it will not be processed server-side. Default to `true`. |
-| `options.cacheKey` | Cache key function (see [dynamic import](/docs/dynamic-import/))      |
+| Arguments                  | Description                                                          |
+| -------------------------- | -------------------------------------------------------------------- |
+| `loadFn`                   | The function call to load the component.                             |
+| `options`                  | Optional options.                                                    |
+| `options.guard`            | Function returning a promise that can delay or cancel loading.       |
+| `options.fallback`         | Fallback displayed during the loading.                               |
+| `options.ssr`              | If `false`, it will not be processed server-side. Default to `true`. |
+| `options.cacheKey`         | Cache key function (see [dynamic import](/docs/dynamic-import/))     |
 
 ```js
 import loadable from '@loadable/component'
 
 const OtherComponent = loadable(() => import('./OtherComponent'))
 ```
+
+
+### `options.guard`
+
+`options.guard` is a function that creates a promise, which can delay or cancel the loading of the component.
+It can be useful to implement timeouts or delays.
+
+It receives a promise as an argument that resolves or rejects when the asynchronous import succeeds or fails.
+It also receives the props as the second argument.
+When/if the returned promise resolves, the component is rendered normally.
+When/if the returned promise rejects, the import is considered to have failed.
+
+For examples, see the documentation on implementing [delays](/docs/delay/) and [timeouts](/docs/timeout/).
 
 ## lazy
 
@@ -89,13 +103,14 @@ OtherComponent.load().then(() => {
 
 Create a loadable library.
 
-| Arguments          | Description                                                          |
-| ------------------ | -------------------------------------------------------------------- |
-| `loadFn`           | The function call to load the component.                             |
-| `options`          | Optional options.                                                    |
-| `options.fallback` | Fallback displayed during the loading.                               |
-| `options.ssr`      | If `false`, it will not be processed server-side. Default to `true`. |
-| `options.cacheKey` | Cache key function (see [dynamic import](/docs/dynamic-import))      |
+| Arguments                  | Description                                                          |
+| -------------------------- | -------------------------------------------------------------------- |
+| `loadFn`                   | The function call to load the component.                             |
+| `options`                  | Optional options.                                                    |
+| `options.guard`            | Function returning a promise that can delay or cancel loading.       |
+| `options.fallback`         | Fallback displayed during the loading.                               |
+| `options.ssr`              | If `false`, it will not be processed server-side. Default to `true`. |
+| `options.cacheKey`         | Cache key function (see [dynamic import](/docs/dynamic-import))      |
 
 ```js
 import loadable from '@loadable/component'

--- a/website/src/pages/docs/api-loadable-component.mdx
+++ b/website/src/pages/docs/api-loadable-component.mdx
@@ -25,6 +25,13 @@ import loadable from '@loadable/component'
 const OtherComponent = loadable(() => import('./OtherComponent'))
 ```
 
+### `loadFn`
+This is a function that returns a promise which resolves to the module where the component is exported.
+
+**Note:** It is highly recommended that you do not do anything in this function except returning an `import()` statement.
+This is because such functionality [will not work](/docs/babel-plugin/#detection-of-wrapped-imports) when using the [Babel plugin](/docs/babel-plugin/) or during [server side rendering](/docs/server-side-rendering/).
+For most use cases you can instead use the [`guard`](/docs/api-loadable-component/#optionsguard) option (e.g. for delays/timeouts), or the [`resolveComponent`](/docs/api-loadable-component/#optionsresolvecomponent) option (e.g. for wrapping the imported component).
+
 
 ### `options.guard`
 

--- a/website/src/pages/docs/babel-plugin.mdx
+++ b/website/src/pages/docs/babel-plugin.mdx
@@ -81,6 +81,26 @@ On client side, the two code are completely compatible.
 
 Please note that babel must not be configured [to strip comments](https://babeljs.io/docs/en/options#comments), since the chunk name is defined in a comment.
 
+## Detection of wrapped imports
+
+During server side rendering, it is necessary for imported components to be resolved synchronously.
+Normally, the Babel plugin automatically transforms asynchronous `import()` statements into the appropriate code to synchronously load the component on the server side.
+
+However, there are some patterns which are not compatible with this process.
+To work consistently in server side rendering, the [`loadFn`](/docs/api-loadable-component/#loadable) must **directly** return an import statement.
+For example, the following code will cause an error when using the babel plugin:
+
+```js
+loadable(() => import('./component').then((imported) => imported))
+loadable(() => pMinDelay(import('./component')))
+```
+
+To avoid this error the `loadFn` must directly return an import promise:
+
+```js
+loadable(() => import('./component'))
+```
+
 ## Loadable detection
 
 The detection of a loadable component is based on the keyword "loadable". It is an opinionated choice, it gives you flexibility but it could also be restrictive.

--- a/website/src/pages/docs/delay.mdx
+++ b/website/src/pages/docs/delay.mdx
@@ -6,14 +6,25 @@ order: 50
 
 # Delay
 
-To avoid flashing a loader if the loading is very fast, you could implement a minimum delay. There is no built-in API in `@loadable/component` but you could do it using [`p-min-delay`](https://github.com/sindresorhus/p-min-delay).
+To avoid flashing a loader if the loading is very fast, you could implement a minimum delay. There is no built-in API in `@loadable/component` but you could do it using the [`guard` option](/docs/api-loadable-component/#optionsguard) and  [`p-min-delay`](https://github.com/sindresorhus/p-min-delay).
 
 ```js
 import loadable from '@loadable/component'
 import pMinDelay from 'p-min-delay'
 
 // Wait a minimum of 200ms before loading home.
-export const OtherComponent = loadable(() =>
-  pMinDelay(import('./OtherComponent'), 200)
+export const OtherComponent = loadable(
+  () => import('./OtherComponent'),
+  {
+    guard: (importPromise) => pMinDelay(importPromise, 200)
+  }
+)
+
+// Wait a different minimum time before loading home, depending on props.
+export const OtherComponent = loadable(
+  () => import('./OtherComponent'),
+  {
+    guard: (importPromise, props) => pMinDelay(importPromise, props.delay)
+  }
 )
 ```

--- a/website/src/pages/docs/timeout.mdx
+++ b/website/src/pages/docs/timeout.mdx
@@ -6,14 +6,25 @@ order: 55
 
 # Timeout
 
-Infinite loading is not good for user experience, to avoid it implementing a timeout is a good workaround. You can do it using a third party module like [`promise-timeout`](https://github.com/building5/promise-timeout):
+Infinite loading is not good for user experience, to avoid it implementing a timeout is a good workaround. You can do it using the [`guard` option](/docs/api-loadable-component/#optionsguard) and a third party module like [`promise-timeout`](https://github.com/building5/promise-timeout):
 
 ```js
 import loadable from '@loadable/component'
 import { timeout } from 'promise-timeout'
 
 // Wait a maximum of 2s before sending an error.
-export const OtherComponent = loadable(() =>
-  timeout(import('./OtherComponent'), 2000)
+export const OtherComponent = loadable(
+  () => import('./OtherComponent'),
+  {
+    guard: (importPromise) => timeout(importPromise, 2000)
+  }
+)
+
+// Wait a different maximum time before sending an error, depending on props.
+export const OtherComponent = loadable(
+  () => import('./OtherComponent'),
+  {
+    guard: (importPromise, props) => timeout(importPromise, props.timeout)
+  }
 )
 ```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

See https://github.com/gregberge/loadable-components/issues/245 and https://github.com/gregberge/loadable-components/pull/483

Basically the aim is to avoid overloading the `loadFn` so that it is less confusing.

#### New `guard` option
Previously to implement a delay, timeout etc the import promise would need to be wrapped, and the wrapped promise was responsible for resolving to the component. This was confusing because it gave the impression that it was possible to resolve to something else (e.g. a named export), and in fact this worked but only on the client side. The new `guard` option does not have to resolve to anything and its resolved value is consistently ignored, so does not create this confusion:

```typescript
import loadable from '@loadable/component';

const LoadableComponent = loadable(() => import('./xyz'), {
  guard: (importPromise) => pMinDelay(importPromise, 1000).then(() => {}),
});
```

####  `guard` has access to props
```typescript
import loadable from '@loadable/component';
const DynamicLoadableComponent = loadable(() => import('./xyz'), {
  guard: (importPromise, props) => pMinDelay(importPromise, props.timeout).then(() => {}),
});
```



## Detailed choices

- The babel plugin has been modified to throw an error if the import creator does anything except directly returning an `import()` statement. This is not necessary for this feature to work (e.g. the error could be hidden behind a flag, or generate a warning now and and an error later). I think it's a good idea though, because it removes the trap where wrapping the `import()` statement (e.g. `loadable(() => import('./xyz').then((mod) => mod.Component))`) works on the client side but not the server side
- To replace the practice of implementing delays/timeouts by wrapping the import promise (e.g. as in the docs for [delay](https://loadable-components.com/docs/delay/)), a new flag is added called `guard`. The consequences of using it are much the same, but this allows the babel plugin to enforce that the `import()` promise is never wrapped (therefore avoiding the client vs SSR confusion). Again, not necessary for the feature to work, but a good idea IMO.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Existing tests have been changed where necessary and new tests have been added for new functionality
