### PR TITLE
docs: fix ChunkExtractor.outputPath comment

### DIFF
--- a/website/src/pages/docs/api-loadable-server.mdx
+++ b/website/src/pages/docs/api-loadable-server.mdx
@@ -16,7 +16,7 @@ Used to collect chunks server-side and get them as script tags or script element
 | `options.statsFile`       | Stats file path generated using `@loadable/webpack-plugin`.                               |
 | `options.stats`           | Stats generated using `@loadable/webpack-plugin`.                                         |
 | `options.entrypoints`     | Webpack entrypoints to load (default to `["main"]`).                                      |
-| `options.outputPath`      | Optional output path (only for `requireEntrypoint`).                                      |
+| `options.outputPath`      | Optional output path (for functions using the file system, like `requireEntrypoints`).    |
 | `options.namespace`       | Namespace of your application (use only if you have several React apps on the same page). |
 | `options.inputFileSystem` | File system used to read files (default to `fs`).                                         |
 | `options.publicPath`      | The public path used at runtime.                                                          |

--- a/website/src/pages/docs/api-loadable-server.mdx
+++ b/website/src/pages/docs/api-loadable-server.mdx
@@ -16,7 +16,7 @@ Used to collect chunks server-side and get them as script tags or script element
 | `options.statsFile`       | Stats file path generated using `@loadable/webpack-plugin`.                               |
 | `options.stats`           | Stats generated using `@loadable/webpack-plugin`.                                         |
 | `options.entrypoints`     | Webpack entrypoints to load (default to `["main"]`).                                      |
-| `options.outputPath`      | Optional output path (for functions using the file system, like `requireEntrypoints`).    |
+| `options.outputPath`      | Optional output path (for functions using the file system, like `requireEntrypoint`).     |
 | `options.namespace`       | Namespace of your application (use only if you have several React apps on the same page). |
 | `options.inputFileSystem` | File system used to read files (default to `fs`).                                         |
 | `options.publicPath`      | The public path used at runtime.                                                          |


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The `ChunkExtractor.outputPath` option is also used by functions like `getCssString`, not only `requireEntrypoint`, so I adjusted that.