### PR TITLE
Fix redundant suspense on hydration

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -129,6 +129,9 @@ function createLoadable({ resolve = identity, render, onLoad }) {
         try {
           const loadedModule = ctor.requireSync(this.props)
           const result = resolve(loadedModule, { Loadable })
+          if (options.suspense) {
+            this.setCache(result)
+          }
           this.state.result = result
           this.state.loading = false
         } catch (error) {


### PR DESCRIPTION
## Summary

`loadSync` does not update cache thus suspense kicks in during hydration, which causes flash of loader. This fix ensures cache is updated when `loadSync` is called if suspense is used to keep hydration as smooth as possible.

## Test plan

⚠️ Not sure if possible to cover it with current tests as they do not seem to have anything related to output of Babel transform

Meanwhile it will be tested in one of my company’s codebases to see if the change causes any regressions, but as I understand it will not cover all possible scenarios.