### PR TITLE
improvement(server): Allow setting async/defer via extraProps

### DIFF
--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -1,0 +1,21 @@
+{
+  "dist/loadable.cjs.js": {
+    "bundled": 12852,
+    "minified": 6137,
+    "gzipped": 2208
+  },
+  "dist/loadable.esm.js": {
+    "bundled": 12469,
+    "minified": 5828,
+    "gzipped": 2141,
+    "treeshaked": {
+      "rollup": {
+        "code": 259,
+        "import_statements": 259
+      },
+      "webpack": {
+        "code": 5061
+      }
+    }
+  }
+}

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -129,7 +129,7 @@ describe('ChunkExtrator', () => {
                 <script async data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\"></script>"
             `)
 
-      expect(extractor.getScriptTags({ defer: true })
+      expect(extractor.getScriptTags({ defer: true, async: false })
       ).toMatchInlineSnapshot(`
                 "<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\">[\\"letters-A\\"]</script>
                 <script defer data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>
@@ -173,6 +173,7 @@ describe('ChunkExtrator', () => {
                   <script
                     async={true}
                     data-chunk="main"
+                    defer={false}
                     src="/dist/node/main.js"
                   />,
                 ]
@@ -194,10 +195,69 @@ describe('ChunkExtrator', () => {
                   <script
                     async={true}
                     data-chunk="main"
+                    defer={false}
                     src="/dist/node/main.js"
                   />,
                 ]
             `)
+      expect(extractor.getScriptElements({ async: false, defer: true })).toMatchInlineSnapshot(`
+                Array [
+                  <script
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "[]",
+                      }
+                    }
+                    id="__LOADABLE_REQUIRED_CHUNKS__"
+                    type="application/json"
+                  />,
+                  <script
+                    async={false}
+                    data-chunk="main"
+                    defer={true}
+                    src="/dist/node/main.js"
+                  />,
+                ]
+      `)
+
+      expect(extractor.getScriptElements({ async: true, defer: true })).toMatchInlineSnapshot(`
+                Array [
+                  <script
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "[]",
+                      }
+                    }
+                    id="__LOADABLE_REQUIRED_CHUNKS__"
+                    type="application/json"
+                  />,
+                  <script
+                    async={true}
+                    data-chunk="main"
+                    defer={true}
+                    src="/dist/node/main.js"
+                  />,
+                ]
+      `)
+      expect(extractor.getScriptElements({ async: false, defer: false })).toMatchInlineSnapshot(`
+                Array [
+                  <script
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": "[]",
+                      }
+                    }
+                    id="__LOADABLE_REQUIRED_CHUNKS__"
+                    type="application/json"
+                  />,
+                  <script
+                    async={false}
+                    data-chunk="main"
+                    defer={false}
+                    src="/dist/node/main.js"
+                  />,
+                ]
+      `)
     })
 
     it('should return other chunks if referenced', () => {
@@ -216,11 +276,13 @@ describe('ChunkExtrator', () => {
                   <script
                     async={true}
                     data-chunk="main"
+                    defer={false}
                     src="/dist/node/main.js"
                   />,
                   <script
                     async={true}
                     data-chunk="letters-A"
+                    defer={false}
                     src="/dist/node/letters-A.js"
                   />,
                 ]
@@ -243,11 +305,13 @@ describe('ChunkExtrator', () => {
                   <script
                     async={true}
                     data-chunk="main"
+                    defer={false}
                     src="/dist/node/main.js"
                   />,
                   <script
                     async={true}
                     data-chunk="letters-E"
+                    defer={false}
                     src="/dist/node/letters-E.js?param"
                   />,
                 ]
@@ -272,12 +336,14 @@ describe('ChunkExtrator', () => {
                   <script
                     async={true}
                     data-chunk="main"
+                    defer={false}
                     nonce="testnonce"
                     src="/dist/node/main.js"
                   />,
                   <script
                     async={true}
                     data-chunk="letters-A"
+                    defer={false}
                     nonce="testnonce"
                     src="/dist/node/letters-A.js"
                   />,
@@ -306,12 +372,14 @@ describe('ChunkExtrator', () => {
                   <script
                     async={true}
                     data-chunk="main"
+                    defer={false}
                     nonce="main"
                     src="/dist/node/main.js"
                   />,
                   <script
                     async={true}
                     data-chunk="letters-A"
+                    defer={false}
                     nonce="letters-A"
                     src="/dist/node/letters-A.js"
                   />,
@@ -340,6 +408,7 @@ describe('ChunkExtrator', () => {
                   <script
                     async={true}
                     data-chunk="main"
+                    defer={false}
                     src="https://cdn.example.org/v1.1.0/main.js"
                   />,
                 ]

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -121,6 +121,34 @@ describe('ChunkExtrator', () => {
                 <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\" nonce=\\"main\\"></script>
                 <script async data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\" nonce=\\"letters-A\\"></script>"
             `)
+
+      expect(extractor.getScriptTags({ async: true })
+      ).toMatchInlineSnapshot(`
+                "<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\">[\\"letters-A\\"]</script>
+                <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>
+                <script async data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\"></script>"
+            `)
+
+      expect(extractor.getScriptTags({ defer: true })
+      ).toMatchInlineSnapshot(`
+                "<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\">[\\"letters-A\\"]</script>
+                <script defer data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>
+                <script defer data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\"></script>"
+            `)
+
+      expect(extractor.getScriptTags({ async: true, defer: true })
+      ).toMatchInlineSnapshot(`
+                "<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\">[\\"letters-A\\"]</script>
+                <script async defer data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>
+                <script async defer data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\"></script>"
+            `)
+
+      expect(extractor.getScriptTags()
+      ).toMatchInlineSnapshot(`
+                "<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\">[\\"letters-A\\"]</script>
+                <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>
+                <script async data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\"></script>"
+            `)
     })
   })
 

--- a/website/src/pages/docs/api-loadable-server.mdx
+++ b/website/src/pages/docs/api-loadable-server.mdx
@@ -61,9 +61,9 @@ const app = <App />
 
 Get scripts as a string of `<script>` tags.
 
-| Arguments                | Description                                                                                                 |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| `attributes` or `attrFn` | Optional attributes added to script tags, or a function that receives a `chunk` and returns the attributes. |
+| Arguments                | Description                                                                                                                                                                                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `attributes` or `attrFn` | Optional attributes added to script tags, or a function that receives a `chunk` and returns the attributes. Adding `async` or `defer` will also affect how the script will be loaded by the browser. (Default: `async: true, defer: false`) |
 
 ```js
 const body = `<body><div id="root">${html}</div>${chunkExtractor.getScriptTags()}</body>`
@@ -73,9 +73,9 @@ const body = `<body><div id="root">${html}</div>${chunkExtractor.getScriptTags()
 
 Get scripts as an array of React `<script>` elements.
 
-| Arguments                | Description                                                                                                     |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `attributes` or `attrFn` | Optional attributes added to script elements, or a function that receives a `chunk` and returns the attributes. |
+| Arguments                | Description                                                                                                                                                                                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `attributes` or `attrFn` | Optional attributes added to script elements, or a function that receives a `chunk` and returns the attributes. Adding `async` or `defer` will also affect how the script will be loaded by the browser. (Default: `async: true, defer: false`) |
 
 ```js
 const body = renderToString(


### PR DESCRIPTION
## Summary

Solving https://github.com/gregberge/loadable-components/issues/337

Default: `async: true, defer: false`

Scenarios: 
* `extractor.getScriptTags({ defer: true })` will return `<script async defer ...></script>` (because `async` is `true` by default)
* `extractor.getScriptTags({ async: true })` will return `<script async ...></script>`
* `extractor.getScriptTags({ async: false, defer: true })` will return `<script defer ...></script>`
* `extractor.getScriptTags()` will return `<script async ...></script>` to keep the default behaviour, preventing breaking change.

Using both `async` and `defer` together might have a valid use case as explained [here](https://stackoverflow.com/questions/50615101/what-does-async-defer-do-when-used-together)

## Test plan

Tests are added to `ChunkExtractor.test.js`