### PR TITLE
Fix ts-loader cannot find module after compilation

### DIFF
--- a/packages/babel-plugin/src/properties/chunkName.js
+++ b/packages/babel-plugin/src/properties/chunkName.js
@@ -132,7 +132,6 @@ export default function chunkNameProperty({ types: t }) {
     const values = getExistingChunkNameComment(callPath)
 
     if (!agressiveImport && values) {
-      addOrReplaceChunkNameComment(callPath, values)
       return t.stringLiteral(values.webpackChunkName)
     }
 


### PR DESCRIPTION
## Summary

After testing, I have clearly identified the source of the problem. Please refer to my minimal reproduction [loadable-babel-plugin](https://github.com/kaysonwu/minimal-reproduction/tree/master/loadable-babel-plugin)

If you just compile with Babel, `Page` is an aggressive import. Unfortunately, when compiled with `ts-loader` in` webpack`, `Page` becomes` BinaryExpression` type.

Personally, the responsibility of the `chunkName` property is to supplement the` webpackChunkName` annotation for import. So if you set `webpackChunkName` yourself, it should not do any work. Therefore, I deleted this line of [code](https://github.com/gregberge/loadable-components/blob/master/packages/babel-plugin/src/properties/chunkName.js#L135)

## Test plan

![test](https://user-images.githubusercontent.com/14865584/77302460-50cfb680-6d2c-11ea-9c46-e49f96d293c9.png)

