### PR TITLE
fix custom webpackChunkName for aggressive import

### DIFF
--- a/packages/babel-plugin/src/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin/src/__snapshots__/index.test.js.snap
@@ -350,6 +350,62 @@ exports[`plugin aggressive import with "webpackChunkName" should replace it 1`] 
 });"
 `;
 
+exports[`plugin aggressive import with "webpackChunkName" should keep it 1`] = `
+"loadable({
+  resolved: {},
+
+  chunkName(props) {
+    return \\"pages/\\" + props.path.replace(/[^a-zA-Z0-9_!§$()=\\\\-^°]+/g, \\"-\\");
+  },
+
+  isReady(props) {
+    const key = this.resolve(props);
+
+    if (this.resolved[key] === false) {
+      return false;
+    }
+
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[key];
+    }
+
+    return false;
+  },
+
+  importAsync: props => import(
+  /* webpackChunkName: \\"pages/[request]\\" */
+  \`./pages/\${props.path}\`),
+
+  requireAsync(props) {
+    const key = this.resolve(props);
+    this.resolved[key] = false;
+    return this.importAsync(props).then(resolved => {
+      this.resolved[key] = true;
+      return resolved;
+    });
+  },
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve(props) {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\`./pages/\${props.path}\`);
+    }
+
+    return eval('require.resolve')(\`./pages/\${props.path}\`);
+  }
+
+});"
+`;
+
 exports[`plugin aggressive import without "webpackChunkName" should support complex request 1`] = `
 "loadable({
   resolved: {},

--- a/packages/babel-plugin/src/index.test.js
+++ b/packages/babel-plugin/src/index.test.js
@@ -100,6 +100,14 @@ describe('plugin', () => {
 
         expect(result).toMatchSnapshot()
       })
+	  
+	    it('should keep it', () => {
+        const result = testPlugin(`
+          loadable(props => import(/* webpackChunkName: "pages/[request]" */ \`./pages/\${props.path}\`))
+        `)
+
+        expect(result).toMatchSnapshot()
+      })
     })
 
     describe('without "webpackChunkName"', () => {


### PR DESCRIPTION
## Summary

`babel-plugin` will ignore the correct custom `webpackChunkName` during dynamic import.  I think it makes sense to keep this, it can store chunks in the specified directory.


## Test plan

![error](https://user-images.githubusercontent.com/14865584/79038350-27a79500-7c0b-11ea-8063-c9e61fd6b2a5.png)

![success](https://user-images.githubusercontent.com/14865584/79038354-2fffd000-7c0b-11ea-98db-dada6a9da11a.png)
