### PR TITLE
fix: memory leak in module cache management, fixes #560

### DIFF
--- a/packages/server/src/util.js
+++ b/packages/server/src/util.js
@@ -1,4 +1,21 @@
-export const clearModuleCache = key => delete require.cache[key]
+export const clearModuleCache = (moduleName) => {
+  const m = require.cache[moduleName];
+  if (m) {
+    // remove self from own parents
+    if (m.parent && m.parent.children) {
+      m.parent.children = m.parent.children.filter(x => x !== m);
+    }
+    // remove self from own children
+    if (m.children) {
+      m.children.forEach(child => {
+        if (child.parent && child.parent === m) {
+          child.parent = null;
+        }
+      })
+    }
+    delete require.cache[moduleName]
+  }
+}
 
 export const smartRequire = modulePath => {
   if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Summary

`smartRequire` is cleaning the cache before requiring module, and that might keep reference to an older version, causing a memory leak.

## Fix

- remove module from the cache
- (added) remove module from parent.children
- (added) remove module from children.parent

## Test plan

The algorithm is borrowed from [rewiremock](https://github.com/theKashey/rewiremock/blob/master/src/wipeCache.js#L34)