### PR TITLE
Sort preload assets so that styles are first

### DIFF
--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -19,7 +19,10 @@ function extensionToScriptType(extension) {
 }
 
 function getAssets(chunks, getAsset) {
-  return uniqBy(flatMap(chunks, chunk => getAsset(chunk)), 'url')
+  return uniqBy(
+    flatMap(chunks, chunk => getAsset(chunk)),
+    'url',
+  )
 }
 
 function handleExtraProps(asset, extraProps) {
@@ -411,6 +414,7 @@ class ChunkExtractor {
     const preloadAssets = this.getChunkChildAssets(chunks, 'preload')
     const prefetchAssets = this.getChunkChildAssets(chunks, 'prefetch')
     return [...mainAssets, ...preloadAssets, ...prefetchAssets]
+      .sort(a => (a.scriptType === 'style' ? -1 : 0))
   }
 
   getLinkTags(extraProps = {}) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6531,6 +6531,13 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
+make-dir@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+  dependencies:
+    semver "^6.0.0"
+
 make-fetch-happen@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz#aa8387104f2687edca01c8687ee45013d02d19bd"


### PR DESCRIPTION
## Summary

When getting the preload assets, sort them so that the style assets are first.

I saw a PR over in next.js (https://github.com/vercel/next.js/pull/9486). Apparently preloading the JS first can slow down some browsers and delay the styles loading and therefore negatively impact performance/lighthouse scores.

I tested the approach on our own site and it led to quite a dramatic improvement in lighthouse score.

## Test plan

I tried to run the tests locally but it errored with something I didn't understand. I'm afraid I don't have the time at the moment to wrap my head around it but figured this PR may be useful to some people so would submit it anyway.