### PR TITLE
Added onload callback option and fixed git-release

### DIFF
--- a/packages/component/rollup.config.js
+++ b/packages/component/rollup.config.js
@@ -12,6 +12,7 @@ const name = 'loadable'
 const globals = {
   react: 'React',
   'hoist-non-react-statics': 'hoistNonReactStatics',
+  "react-is": "react-is",
 }
 
 const external = id => !id.startsWith('.') && !id.startsWith('/')

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -150,6 +150,11 @@ function createLoadable({
             onLoad(this.state.result, this.props)
           })
         }
+        if (options.onLoad){
+          setTimeout(() => {
+            options.onLoad()
+          })
+        }
       }
 
       loadSync() {

--- a/packages/component/src/loadable.test.js
+++ b/packages/component/src/loadable.test.js
@@ -76,6 +76,17 @@ describe('#loadable', () => {
     await wait(() => expect(container).toHaveTextContent('loaded'))
   })
 
+  it('should call onload callback option', async () => {
+    const load = createLoadFunction()
+    const onLoadCallback = jest.fn();
+    const Component = loadable(load, { onLoad: onLoadCallback })
+    const { container } = render(<Component />)
+    expect(container).toBeEmpty()
+    load.resolve({ default: () => 'loaded' })
+    await wait(() => expect(container).toHaveTextContent('loaded'))
+    expect(onLoadCallback).toHaveBeenCalledTimes(1)
+  })
+
   it('supports preload', async () => {
     const load = createLoadFunction()
     const Component = loadable(load)

--- a/scripts/git-release.sh
+++ b/scripts/git-release.sh
@@ -10,6 +10,11 @@ git commit -m "Publish to git"
 
 for DIR in $(yarn run -s lerna changed --parseable); do
   (
+    if [ $(basename $DIR) = "codemod" ];
+    then
+      continue
+    fi
+        
     VERSION=$(cat "${DIR}/package.json" | jq -r '.version')
     NAME=$(cat "${DIR}/package.json" | jq -r '.name')
 


### PR DESCRIPTION
## Summary
When loading the components, the component creator has no information regarding the state of the component.
Due to async nature of loading, the parent componentDidUpdate is called before lazy-loaded child is rendered. This makes state checks very complex - the only option is for the child component to emit some custom "Hey I rendered!" action/event.
This PR simply adds a callback to the options.

Note that after the component is loaded one should actually start using componentDidUpdate, as subsequent re-renders of a component are not passing via this onload callback. So basically you have to statefully track if a component has been rendered once. This state tracking may be implemented in loadable-components eventually.

## Test plan

I am using the updated library in my project, and this works fine. I added a unit test that checks this.
Since I am using my own fork, i had to make a package and fix the git-release.sh script - didn't seem like this was working.