### PR TITLE
feat: allow setting displayName

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -339,6 +339,10 @@ function createLoadable({
 
     Loadable.load = props => ctor.requireAsync(props)
 
+    if (options.displayName) {
+      Loadable.displayName = options.displayName;
+    }
+
     return Loadable
   }
 

--- a/packages/component/src/loadable.test.js
+++ b/packages/component/src/loadable.test.js
@@ -149,6 +149,14 @@ describe('#loadable', () => {
     await wait(() => expect(container).toHaveTextContent('James Bond'))
   })
 
+  it('sets component displayName', async () => {
+    const load = resolvedToDefault(({ name }) => name)
+    const Component = loadable(load, {
+      displayName: 'TestComponent'
+    })
+    expect(Component.displayName).toEqual('TestComponent')
+  })
+
   it('should update component if props change', async () => {
     const load = resolvedToDefault(({ value }) => value)
     const Component = loadable(load)


### PR DESCRIPTION
## Summary

It should simplify a bit setting a `displayName` property on a component.

## Test plan

Instead of doing:
```js
const SomeComponent = loadable(() => import('./SomeComponent.js'), {
  ssr: false,
});

SomeComponent.displayName = 'SomeComponent';
```

This PR allows to simplify it into:
```js
const SomeComponent = loadable(() => import('./SomeComponent.js'), {
  ssr: false,
  displayName: 'SomeComponent',
});
```

It is especially useful when there are several lazy-loaded components:
```js
const LoginPage = loadable(() => import('./LoginPage.js'), {
  ssr: false,
});

LoginPage.displayName = 'LoginPage';

const RegisterPage = loadable(() => import('./RegisterPage.js'), {
  ssr: false,
});

RegisterPage.displayName = 'RegisterPage';

const RememberPasswordPage = loadable(() => import('./RememberPasswordPage.js'), {
  ssr: false,
});

RememberPasswordPage.displayName = 'RememberPasswordPage';

const DeleteAccountPage = loadable(() => import('./DeleteAccountPage.js'), {
  ssr: false,
});

DeleteAccountPage.displayName = 'DeleteAccountPage';
```

⬇️ 

```js
const LoginPage = loadable(() => import('./LoginPage.js'), {
  ssr: false,
  displayName: 'LoginPage',
});

const RegisterPage = loadable(() => import('./RegisterPage.js'), {
  ssr: false,
  displayName: 'RegisterPage',
});

const RememberPasswordPage = loadable(() => import('./RememberPasswordPage.js'), {
  ssr: false,
  displayName: 'RememberPasswordPage',
});

const DeleteAccountPage = loadable(() => import('./DeleteAccountPage.js'), {
  ssr: false,
  displayName: 'DeleteAccountPage',
});
```