### PR TITLE
fix: do not derive cache key if component is static

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -56,7 +56,7 @@ function createLoadable({
       if (ctor.resolve) {
         return ctor.resolve(props)
       }
-      return null
+      return "static"
     }
 
     /**
@@ -181,7 +181,7 @@ function createLoadable({
        * @returns {Component|string}
        */
       getCacheKey() {
-        return getCacheKey(this.props) || JSON.stringify(this.props)
+        return getCacheKey(this.props)
       }
 
       /**


### PR DESCRIPTION
##  Summary
For components, which are static, there is no reason to derive cache key from props.

👉 Do not derive cache key if component is static, fixes #629