### PR TITLE
chore(tests): build examples during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ branches:
 
 script:
   - yarn ci
+  - yarn --cwd examples/typescript && yarn --cwd examples/typescript build
+  - yarn --cwd examples/webpack/webpack4 && yarn --cwd examples/webpack/webpack4 build
+  - yarn --cwd examples/webpack/webpack5 && yarn --cwd examples/webpack/webpack5 build
+
 
 notifications:
   email: false


### PR DESCRIPTION
In order to maintain better integrity:
 -  run `build` for selected examples during CI

This shall ensure that webpack integration is working correctly, as well as TypeScript integration (for selected use cases)