### PR TITLE
feat: filter chunk assets

### DIFF
--- a/packages/server/__fixtures__/stats.json
+++ b/packages/server/__fixtures__/stats.json
@@ -1,8 +1,8 @@
 {
   "errors": [],
   "warnings": [],
-  "version": "4.41.0",
-  "hash": "3e6566a0799a062ba9c6",
+  "version": "4.46.0",
+  "hash": "6bd3f3f9c2fe8a3d1b0f",
   "publicPath": "/dist/node/",
   "outputPath": "../../examples/server-side-rendering/public/dist/node",
   "assetsByChunkName": {
@@ -201,7 +201,7 @@
     },
     {
       "name": "main.js",
-      "size": 13586,
+      "size": 13582,
       "chunks": [
         "main"
       ],
@@ -511,7 +511,7 @@
       "files": [
         "Y-file.js"
       ],
-      "hash": "b4d8d777cba1919ad570",
+      "hash": "e57a651e1c0b1f68eff1",
       "siblings": [],
       "parents": [
         "main"
@@ -535,7 +535,7 @@
         "letters-A.css",
         "letters-A.js"
       ],
-      "hash": "0c15a7fd2a22c9b265fa",
+      "hash": "eb9a32a6db31b2899f58",
       "siblings": [],
       "parents": [
         "main"
@@ -559,7 +559,7 @@
         "letters-A-css.css",
         "letters-A-css.js"
       ],
-      "hash": "8028b2657cb1626f301d",
+      "hash": "89c9874f01b1e3949436",
       "siblings": [],
       "parents": [
         "main"
@@ -582,7 +582,7 @@
       "files": [
         "letters-B.js"
       ],
-      "hash": "84099bce3af835a0d9b3",
+      "hash": "a3dc7ba1a249083fd1a2",
       "siblings": [],
       "parents": [
         "main"
@@ -605,7 +605,7 @@
       "files": [
         "letters-C.js"
       ],
-      "hash": "e2e5758bdd6bdbcd8c64",
+      "hash": "0873e4e07b1949c2212a",
       "siblings": [],
       "parents": [
         "main"
@@ -628,7 +628,7 @@
       "files": [
         "letters-D.js"
       ],
-      "hash": "698cbca6bfdf9fbf1074",
+      "hash": "611804f2589a69fd908c",
       "siblings": [],
       "parents": [
         "main"
@@ -651,7 +651,7 @@
       "files": [
         "letters-E.js"
       ],
-      "hash": "21404278fb1a3c5e67ad",
+      "hash": "1c23ff7e41756c9ac4c7",
       "siblings": [],
       "parents": [
         "main"
@@ -674,7 +674,7 @@
       "files": [
         "letters-E-param.js"
       ],
-      "hash": "5253b4e1e5e59e52c4fa",
+      "hash": "94c459d9fc0e6f9c1ec1",
       "siblings": [],
       "parents": [
         "main"
@@ -697,7 +697,7 @@
       "files": [
         "letters-F.js"
       ],
-      "hash": "4f9fef34f4df74392d9f",
+      "hash": "d0a6bbc708c2980012bc",
       "siblings": [],
       "parents": [
         "main"
@@ -713,14 +713,14 @@
       "rendered": true,
       "initial": false,
       "entry": false,
-      "size": 153,
+      "size": 166,
       "names": [
         "letters-G"
       ],
       "files": [
         "letters-G.js"
       ],
-      "hash": "0119642059748a42b121",
+      "hash": "05ba7bf72eab83fb0877",
       "siblings": [],
       "parents": [
         "main"
@@ -743,7 +743,7 @@
       "files": [
         "letters-Z-file.js"
       ],
-      "hash": "21d8cde8b6e3c5c8b362",
+      "hash": "9a7d56059319a25320c1",
       "siblings": [],
       "parents": [
         "main"
@@ -759,7 +759,7 @@
       "rendered": true,
       "initial": true,
       "entry": true,
-      "size": 14368,
+      "size": 14654,
       "names": [
         "main"
       ],
@@ -767,7 +767,7 @@
         "main.css",
         "main.js"
       ],
-      "hash": "f2e7d69a2c13975fa3a9",
+      "hash": "af91cc7eead6c72e727d",
       "siblings": [],
       "parents": [],
       "children": [
@@ -849,7 +849,7 @@
           "files": [
             "*"
           ],
-          "hash": "ae6a81c348917f377d61",
+          "hash": "0bd7ee33f38ce0c05d66",
           "siblings": [],
           "parents": [],
           "children": [],
@@ -1010,7 +1010,7 @@
           "files": [
             "*"
           ],
-          "hash": "3de4c2d6fb7d56e8b981",
+          "hash": "db3f80a505f46970d1ec",
           "siblings": [],
           "parents": [],
           "children": [],
@@ -1126,5 +1126,6 @@
       "children": [],
       "name": "mini-css-extract-plugin node_modules/css-loader/dist/cjs.js!src/client/main.css"
     }
-  ]
+  ],
+  "generator": "loadable-components"
 }

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -202,7 +202,7 @@ class ChunkExtractor {
     namespace = '',
     outputPath,
     publicPath,
-    filter,
+    filterChunk,
     inputFileSystem = fs,
   } = {}) {
     this.namespace = namespace
@@ -211,7 +211,7 @@ class ChunkExtractor {
     this.outputPath = outputPath || this.stats.outputPath
     this.statsFile = statsFile
     this.entrypoints = Array.isArray(entrypoints) ? entrypoints : [entrypoints]
-    this.filter = filter || Boolean
+    this.filterChunk = filterChunk || Boolean
     this.chunks = []
     this.inputFileSystem = inputFileSystem
     this.assetsByName = this.stats.assets.reduce((acc, asset) => {
@@ -237,7 +237,7 @@ class ChunkExtractor {
   }
 
   isExctractableChunkAsset(chunk) {
-    return isValidChunkAsset(chunk) && this.filter(chunk)
+    return isValidChunkAsset(chunk) && this.filterChunk(chunk)
   }
 
   createChunkAsset({ filename, chunk, type, linkType }) {

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -306,33 +306,33 @@ describe('ChunkExtrator', () => {
       `)
     })
 
-    it.only('should use filter from options', () => {
-      extractor = new ChunkExtractor({
-        namespace: 'testapp',
+    it('should use filterChunk from options', () => {
+      const filteredExtractor = new ChunkExtractor({
         stats,
-        outputPath: path.resolve(__dirname, '../__fixtures__'),
-        filterChunk: ({ info }) => !info.hotModuleReplacement,
+        outputPath: targetPath,
+        filterChunk: ({ chunk }) => chunk !== 'letters-B',
       })
-      extractor.addChunk('letters-A')
+      filteredExtractor.addChunk('letters-A')
+      filteredExtractor.addChunk('letters-B')
 
-      expect(extractor.getScriptElements()).toMatchInlineSnapshot(`
+      expect(filteredExtractor.getScriptElements()).toMatchInlineSnapshot(`
         Array [
           <script
             dangerouslySetInnerHTML={
               Object {
-                "__html": "[\\"letters-A\\"]",
+                "__html": "[\\"letters-A\\",\\"letters-B\\"]",
               }
             }
-            id="testapp__LOADABLE_REQUIRED_CHUNKS__"
+            id="__LOADABLE_REQUIRED_CHUNKS__"
             type="application/json"
           />,
           <script
             dangerouslySetInnerHTML={
               Object {
-                "__html": "{\\"namedChunks\\":[\\"letters-A\\"]}",
+                "__html": "{\\"namedChunks\\":[\\"letters-A\\",\\"letters-B\\"]}",
               }
             }
-            id="testapp__LOADABLE_REQUIRED_CHUNKS___ext"
+            id="__LOADABLE_REQUIRED_CHUNKS___ext"
             type="application/json"
           />,
           <script

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -311,7 +311,7 @@ describe('ChunkExtrator', () => {
         namespace: 'testapp',
         stats,
         outputPath: path.resolve(__dirname, '../__fixtures__'),
-        filter: ({ info }) => !info.hotModuleReplacement,
+        filterChunk: ({ info }) => !info.hotModuleReplacement,
       })
       extractor.addChunk('letters-A')
 

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -306,6 +306,49 @@ describe('ChunkExtrator', () => {
       `)
     })
 
+    it.only('should use filter from options', () => {
+      extractor = new ChunkExtractor({
+        namespace: 'testapp',
+        stats,
+        outputPath: path.resolve(__dirname, '../__fixtures__'),
+        filter: ({ info }) => !info.hotModuleReplacement,
+      })
+      extractor.addChunk('letters-A')
+
+      expect(extractor.getScriptElements()).toMatchInlineSnapshot(`
+        Array [
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "[\\"letters-A\\"]",
+              }
+            }
+            id="testapp__LOADABLE_REQUIRED_CHUNKS__"
+            type="application/json"
+          />,
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "{\\"namedChunks\\":[\\"letters-A\\"]}",
+              }
+            }
+            id="testapp__LOADABLE_REQUIRED_CHUNKS___ext"
+            type="application/json"
+          />,
+          <script
+            async={true}
+            data-chunk="main"
+            src="/dist/node/main.js"
+          />,
+          <script
+            async={true}
+            data-chunk="letters-A"
+            src="/dist/node/letters-A.js"
+          />,
+        ]
+      `)
+    })
+
     it('should add extra props if specified - function argument', () => {
       extractor.addChunk('letters-A')
       expect(


### PR DESCRIPTION
## Summary

In development, when doing SSR with HMR you don't want the hmr related files to be linked by the served html. The `filter` option in addition to the new `info` property added to chunk assets make it possible.

I favored this approach rather than an _"excludeHmrFiles"_ type option as it could serve other purposes and remain relevant even if hmr is abandoned in the future.

## Test plan

Using webpack with hmr enabled, instanciate your `ChunkExtractor` like :

```js
import { ChunkExtractor } from '@loadable/server'

const extractor = new ChunkExtractor({
  statsFile: '../dist/loadable-stats.json',
  filter: ({ info }) => !info.hotModuleReplacement,
});
```

All files relative to hmr (suffixed with _"-wps-hmr"_ by default) should be excluded from the results of `getScriptTags`, `getScriptElements`,…