### PR TITLE
fix: DeprecationWarning Compilation.assets

### DIFF
--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -29,14 +29,13 @@ class LoadablePlugin {
     const result = JSON.stringify(stats, null, 2)
 
     if (this.opts.outputAsset) {
-      hookCompiler.assets[this.opts.filename] = {
-        source() {
-          return result
-        },
-        size() {
-          return result.length
-        },
-      }
+      const outputPath = nodePath.resolve(
+        this.compiler.options.output.path,
+        this.opts.filename,
+      )
+      const file = fs.createWriteStream(outputPath)
+      file.write(result)
+      file.end()
     }
 
     if (this.opts.writeToDisk) {
@@ -50,7 +49,7 @@ class LoadablePlugin {
    * Write Assets Manifest file
    * @method writeAssetsFile
    */
-  writeAssetsFile = manifest => {
+  writeAssetsFile = (manifest) => {
     const outputFolder =
       this.opts.writeToDisk.filename || this.compiler.options.output.path
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This is to fix Webpack 5 deprecation warning :

```terminal
(node:4312) [DEP_WEBPACK_COMPILATION_ASSETS] DeprecationWarning: Compilation.assets will be frozen in future, all modifications are deprecated.
BREAKING CHANGE: No more changes should happen to Compilation.assets after sealing the Compilation.
        Do changes to assets earlier, e. g. in Compilation.hooks.processAssets.
        Make sure to select an appropriate stage from Compilation.PROCESS_ASSETS_STAGE_*.
```

This warning was trace to [line 32](https://github.com/gregberge/loadable-components/blob/89cf124f9079395f2d77038033e472b22c04deb6/packages/webpack-plugin/src/index.js#L32) of packages/webpack-plugin/src/index.js. This warning will fired when plugin emit `loadable-stats.json`

## Test plan

This version of code is compatible with Webpack version 4 and 5. I've already used in my own  project. Original version uses compilation.assets to emit `loadable-stats.json` . This version will produce similar output by not using compilation hook. This should work even `compilation.getStats().toJson()` produces huge bytes of strings.

