### PR TITLE
fix: remove main asset path query

### DIFF
--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -363,7 +363,7 @@ class ChunkExtractor {
         smartRequire(path.join(this.outputPath, name.split('?')[0]))
       })
 
-    return smartRequire(mainAsset.path)
+    return smartRequire(mainAsset.path.split('?')[0])
   }
 
   // Main assets


### PR DESCRIPTION
## Summary

`requireEntrypoint` failed when main asset's path has query.

![image](https://user-images.githubusercontent.com/3380894/104296452-94ceba80-54fc-11eb-83e7-d149c621bc38.png)
