### PR TITLE
Include build library step in SSR Example README

### DIFF
--- a/examples/server-side-rendering/README.md
+++ b/examples/server-side-rendering/README.md
@@ -8,20 +8,25 @@ Steps:
 git clone https://github.com/gregberge/loadable-components.git
 ```
 
-2. move into example directory
+2. Install [https://yarnpkg.com/lang/en/docs/install](yarn) if haven't already
+3. Install libary dependencies and build library
+```bash
+yarn
+yarn build
+```
+
+4. Move into example directory
 
 ```bash
 cd ./loadable-components/examples/server-side-rendering
 ```
-
-3. install [https://yarnpkg.com/lang/en/docs/install](yarn) if haven't already
-4. install project dependencies
+5. Install project dependencies
 
 ```bash
 yarn
 ```
 
-5. run locally or build and serve
+5. Run locally or build and serve
 
 ```bash
 yarn dev


### PR DESCRIPTION
The SSR example doesn't work without building the library, add that as a step for running the example.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The SSR example doesn't work without building the library, add that as a step for running the example. Per issue: https://github.com/gregberge/loadable-components/issues/693

## Test plan

Not needed