### PR TITLE
feat: support multiple Webpack runtimes

### DIFF
--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/loadable.cjs.js": {
-    "bundled": 16441,
-    "minified": 7281,
-    "gzipped": 2578
+    "bundled": 16504,
+    "minified": 7301,
+    "gzipped": 2586
   },
   "dist/loadable.esm.js": {
-    "bundled": 16062,
-    "minified": 6977,
-    "gzipped": 2508,
+    "bundled": 16125,
+    "minified": 6997,
+    "gzipped": 2516,
     "treeshaked": {
       "rollup": {
         "code": 276,

--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/loadable.cjs.js": {
-    "bundled": 16354,
-    "minified": 7304,
-    "gzipped": 2565
+    "bundled": 16441,
+    "minified": 7281,
+    "gzipped": 2578
   },
   "dist/loadable.esm.js": {
-    "bundled": 15975,
-    "minified": 7000,
-    "gzipped": 2495,
+    "bundled": 16062,
+    "minified": 6977,
+    "gzipped": 2508,
     "treeshaked": {
       "rollup": {
         "code": 276,

--- a/packages/component/src/loadableReady.js
+++ b/packages/component/src/loadableReady.js
@@ -49,8 +49,11 @@ export default function loadableReady(
   let resolved = false
 
   return new Promise(resolve => {
-    window.__LOADABLE_LOADED_CHUNKS__ = window.__LOADABLE_LOADED_CHUNKS__ || []
-    const loadedChunks = window.__LOADABLE_LOADED_CHUNKS__
+    const prefix = namespace ? `__${namespace}` : ''
+    const loadedChunksKey = `${prefix}__LOADABLE_LOADED_CHUNKS__`
+
+    window[loadedChunksKey] = window[loadedChunksKey] || []
+    const loadedChunks = window[loadedChunksKey]
     const originalPush = loadedChunks.push.bind(loadedChunks)
 
     function checkReadyState() {

--- a/packages/component/src/loadableReady.js
+++ b/packages/component/src/loadableReady.js
@@ -8,7 +8,7 @@ const BROWSER = typeof window !== 'undefined'
 
 export default function loadableReady(
   done = () => {},
-  { namespace = '' } = {},
+  { namespace = '', chunkLoadingGlobal = '__LOADABLE_LOADED_CHUNKS__' } = {},
 ) {
   if (!BROWSER) {
     warn('`loadableReady()` must be called in browser only')
@@ -49,11 +49,8 @@ export default function loadableReady(
   let resolved = false
 
   return new Promise(resolve => {
-    const prefix = namespace ? `__${namespace}` : ''
-    const loadedChunksKey = `${prefix}__LOADABLE_LOADED_CHUNKS__`
-
-    window[loadedChunksKey] = window[loadedChunksKey] || []
-    const loadedChunks = window[loadedChunksKey]
+    window[chunkLoadingGlobal] = window[chunkLoadingGlobal] || []
+    const loadedChunks = window[chunkLoadingGlobal]
     const originalPush = loadedChunks.push.bind(loadedChunks)
 
     function checkReadyState() {

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -10,9 +10,9 @@ class LoadablePlugin {
     path,
     writeToDisk,
     outputAsset = true,
-    namespace = null,
+    chunkLoadingGlobal = '__LOADABLE_LOADED_CHUNKS__',
   } = {}) {
-    this.opts = { filename, writeToDisk, outputAsset, path, namespace }
+    this.opts = { filename, writeToDisk, outputAsset, path, chunkLoadingGlobal }
 
     // The Webpack compiler instance
     this.compiler = null
@@ -86,13 +86,12 @@ class LoadablePlugin {
     this.compiler = compiler
 
     const version = 'jsonpFunction' in compiler.options.output ? 4 : 5
-    const namespace = this.opts.namespace ? `__${this.opts.namespace}` : ''
 
-    // Add a custom chunk loading callback __LOADABLE_LOADED_CHUNKS__
+    // Add a custom chunk loading callback
     if (version === 4) {
-      compiler.options.output.jsonpFunction = `${namespace}__LOADABLE_LOADED_CHUNKS__`
+      compiler.options.output.jsonpFunction = this.opts.chunkLoadingGlobal
     } else {
-      compiler.options.output.chunkLoadingGlobal = `${namespace}__LOADABLE_LOADED_CHUNKS__`
+      compiler.options.output.chunkLoadingGlobal = this.opts.chunkLoadingGlobal
     }
 
     if (this.opts.outputAsset || this.opts.writeToDisk) {

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -10,8 +10,9 @@ class LoadablePlugin {
     path,
     writeToDisk,
     outputAsset = true,
+    namespace = null,
   } = {}) {
-    this.opts = { filename, writeToDisk, outputAsset, path }
+    this.opts = { filename, writeToDisk, outputAsset, path, namespace }
 
     // The Webpack compiler instance
     this.compiler = null
@@ -85,12 +86,13 @@ class LoadablePlugin {
     this.compiler = compiler
 
     const version = 'jsonpFunction' in compiler.options.output ? 4 : 5
+    const namespace = this.opts.namespace ? `__${this.opts.namespace}` : ''
 
     // Add a custom chunk loading callback __LOADABLE_LOADED_CHUNKS__
     if (version === 4) {
-      compiler.options.output.jsonpFunction = '__LOADABLE_LOADED_CHUNKS__'
+      compiler.options.output.jsonpFunction = `${namespace}__LOADABLE_LOADED_CHUNKS__`
     } else {
-      compiler.options.output.chunkLoadingGlobal = '__LOADABLE_LOADED_CHUNKS__'
+      compiler.options.output.chunkLoadingGlobal = `${namespace}__LOADABLE_LOADED_CHUNKS__`
     }
 
     if (this.opts.outputAsset || this.opts.writeToDisk) {

--- a/website/src/pages/docs/api-loadable-component.mdx
+++ b/website/src/pages/docs/api-loadable-component.mdx
@@ -26,6 +26,7 @@ const OtherComponent = loadable(() => import('./OtherComponent'))
 ```
 
 ### `options.resolveComponent`
+
 This is a function that receives the imported module (what the `import()` call resolves to) and the props, and returns the component.
 
 The default value assumes that the component is exported as a default export.
@@ -43,17 +44,16 @@ export const Orange = () => 'Orange!'
 // loadable.js
 
 const LoadableApple = loadable(() => import('./components'), {
-  resolveComponent: (components) => components.Apple,
+  resolveComponent: components => components.Apple,
 })
 
 const LoadableOrange = loadable(() => import('./components'), {
-  resolveComponent: (components) => components.Orange,
+  resolveComponent: components => components.Orange,
 })
 
 const LoadableFruit = loadable(() => import('./components'), {
   resolveComponent: (components, props) => components[props.fruit],
 })
-
 ```
 
 **Note:** The default `resolveComponent` breaks Typescript type inference due to CommonJS compatibility.
@@ -169,11 +169,12 @@ A component created using `loadable.lib` or `lazy.lib`.
 
 Wait for all loadable components to be loaded. This method must only be used with Server Side Rendering, see [Server Side Rendering guide](/docs/server-side-rendering/).
 
-| Arguments           | Description                                                                               |
-| ------------------- | ----------------------------------------------------------------------------------------- |
-| `done`              | Function called when all components are loaded.                                           |
-| `options`           | Optional options.                                                                         |
-| `options.namespace` | Namespace of your application (use only if you have several React apps on the same page). |
+| Arguments                    | Description                                                                               |
+| ---------------------------- | ----------------------------------------------------------------------------------------- |
+| `done`                       | Function called when all components are loaded.                                           |
+| `options`                    | Optional options.                                                                         |
+| `options.namespace`          | Namespace of your application (use only if you have several React apps on the same page). |
+| `options.chunkLoadingGlobal` | A custom `chunkLoadingGlobal` if set in the Webpack plugin                                |
 
 ```js
 import { loadableReady } from '@loadable/component'

--- a/website/src/pages/docs/api-loadable-webpack-plugin.mdx
+++ b/website/src/pages/docs/api-loadable-webpack-plugin.mdx
@@ -10,14 +10,14 @@ order: 30
 
 Create a webpack loadable plugin.
 
-| Arguments                      | Description                                                                         |
-| ------------------------------ | ----------------------------------------------------------------------------------- |
-| `options`                      | Optional options                                                                    |
-| `options.filename`             | Stats filename (default to `loadable-stats.json`)                                   |
-| `options.outputAsset`          | Always write stats file to the `output.path` directory. Defaults to `true`          |
-| `options.writeToDisk`          | Accepts `boolean` or `object`. Always write stats file to disk. Default to `false`. |
-| `options.writeToDisk.filename` | Write assets to disk at given `filename` location                                   |
-| `options.namespace`            | Namespaces the chunk loading global to allow multiple Webpack runtimes              |
+| Arguments                      | Description                                                                                  |
+| ------------------------------ | -------------------------------------------------------------------------------------------- |
+| `options`                      | Optional options                                                                             |
+| `options.filename`             | Stats filename (default to `loadable-stats.json`)                                            |
+| `options.outputAsset`          | Always write stats file to the `output.path` directory. Defaults to `true`                   |
+| `options.writeToDisk`          | Accepts `boolean` or `object`. Always write stats file to disk. Default to `false`.          |
+| `options.writeToDisk.filename` | Write assets to disk at given `filename` location                                            |
+| `options.chunkLoadingGlobal`   | Overrides Webpack's `chunkLoadingGlobal` allowing multiple Webpack runtimes on the same page |
 
 ```js
 new LoadablePlugin({ filename: 'stats.json', writeToDisk: true })

--- a/website/src/pages/docs/api-loadable-webpack-plugin.mdx
+++ b/website/src/pages/docs/api-loadable-webpack-plugin.mdx
@@ -17,6 +17,7 @@ Create a webpack loadable plugin.
 | `options.outputAsset`          | Always write stats file to the `output.path` directory. Defaults to `true`          |
 | `options.writeToDisk`          | Accepts `boolean` or `object`. Always write stats file to disk. Default to `false`. |
 | `options.writeToDisk.filename` | Write assets to disk at given `filename` location                                   |
+| `options.namespace`            | Namespaces the chunk loading global to allow multiple Webpack runtimes              |
 
 ```js
 new LoadablePlugin({ filename: 'stats.json', writeToDisk: true })


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Addresses: https://github.com/gregberge/loadable-components/issues/635

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We have a case where we're running multiple Webpack runtimes on the same page which both use Loadable. This change adds an optional `chunkLoadingGlobal` option to `LoadablePlugin` and `loadableReady` which namespaces `jsonpFunction` or `chunkLoadingGlobal`.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I didn't see unit tests for `LoadablePlugin` but I tested in a local application which rendered two Webpack apps in the same page. I can push this to a repo if you'd like. It correctly adds the namespace:

`namespace: 'header'`
```
(window["__header__LOADABLE_LOADED_CHUNKS__"] = window["__header__LOADABLE_LOADED_CHUNKS__"] || []).push([["foo"],{
```

`namespace: 'content'`
```
(window["__content__LOADABLE_LOADED_CHUNKS__"] = window["__content__LOADABLE_LOADED_CHUNKS__"] || []).push([["foo"],{
```
