### PR TITLE
[perf] Set all:false in stats.toJson call

### DIFF
--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -23,13 +23,11 @@ class LoadablePlugin {
       assets: true,
       chunks: true,
       chunkGroups: true,
-      errorDetails: false,
+      chunkGroupChildren: true,
       hash: true,
-      modules: false,
+      ids: true,
       outputPath: true,
       publicPath: true,
-      source: false,
-      timings: false,
     })
 
     stats.generator = 'loadable-components'

--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -19,13 +19,16 @@ class LoadablePlugin {
 
   handleEmit = compilation => {
     const stats = compilation.getStats().toJson({
-      hash: true,
-      publicPath: true,
+      all: false,
       assets: true,
       chunks: true,
-      modules: false,
-      source: false,
+      chunkGroups: true,
       errorDetails: false,
+      hash: true,
+      modules: false,
+      outputPath: true,
+      publicPath: true,
+      source: false,
       timings: false,
     })
 


### PR DESCRIPTION
## Summary
I noticed while upgrading a codebase from webpack v4 -> v5 that there seemed to be a significant increase in incremental build times. 

From a local profile, the time seemed to be spent on a `stats.toJson` call originating from the loadable webpack plugin
![image](https://user-images.githubusercontent.com/6487551/109410412-680d2000-794f-11eb-9e37-c44b1e81ddb0.png)

Updating the `toJson` call so that it specifies [all: false](https://webpack.js.org/configuration/stats/#statsall) improves the time spent on this call from 40seconds -> 55ms (for the specific codebase i tested on)
![image](https://user-images.githubusercontent.com/6487551/109410465-be7a5e80-794f-11eb-8d70-3e70e74fa73e.png)

I checked this change against webpack 4 on our codebase and it also reduced the time spent from ~9s -> 500ms
![image](https://user-images.githubusercontent.com/6487551/109410505-1913ba80-7950-11eb-8d85-6612b2b44706.png)
![image](https://user-images.githubusercontent.com/6487551/109410511-216bf580-7950-11eb-8841-f39863f587fb.png)

## Test plan
I tested this change locally against both a webpack 4 build and webpack 5 build and loadable worked as expected in both cases.

