### PR TITLE
fix: add displayNames to generated components

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -26,11 +26,18 @@ function resolveConstructor(ctor) {
   return ctor
 }
 
-const withChunkExtractor = Component => props => (
-  <Context.Consumer>
-    {extractor => <Component __chunkExtractor={extractor} {...props} />}
-  </Context.Consumer>
-)
+const withChunkExtractor = Component => {
+  const LoadableWithChunkExtractor = props => (
+    <Context.Consumer>
+      {extractor => <Component __chunkExtractor={extractor} {...props} />}
+    </Context.Consumer>
+  )
+  if (Component.displayName) {
+    LoadableWithChunkExtractor.displayName =
+      `${Component.displayName}WithChunkExtractor`;
+  }
+  return LoadableWithChunkExtractor
+}
 
 const identity = v => v
 
@@ -331,6 +338,8 @@ function createLoadable({
     const Loadable = React.forwardRef((props, ref) => (
       <EnhancedInnerLoadable forwardedRef={ref} {...props} />
     ))
+
+    Loadable.displayName = 'Loadable'
 
     // In future, preload could use `<link rel="preload">`
     Loadable.preload = props => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
Fixes #727

## Summary

Adding `displayName`s to the generated loadable components makes them identifiable in react devtools.

## Test plan

Acceptance testing: Load one of the examples in a browser with react-devtools, make sure that the loadable wrappers dont just say "Anonymous"

Unit testing: just make sure that `displayName` is set on generated components.
