### PR TITLE
fix docs: import() syntax a part of language

### DIFF
--- a/website/src/pages/docs/code-splitting.mdx
+++ b/website/src/pages/docs/code-splitting.mdx
@@ -35,7 +35,7 @@ import('./math').then(math => {
 ```
 
 > Note:
-> The dynamic import() syntax is a ECMAScript (JavaScript) proposal not currently part of the language standard. It is expected to be accepted in the near future.
+> The dynamic import() syntax is officially a part of ECMAScript 2020 specification. Hovewer to use this syntax in prior language versions you still need to bundle your code with Webpack.
 
 When Webpack comes across this syntax, it automatically starts code-splitting your app.
 

--- a/website/src/pages/docs/code-splitting.mdx
+++ b/website/src/pages/docs/code-splitting.mdx
@@ -35,7 +35,7 @@ import('./math').then(math => {
 ```
 
 > Note:
-> The dynamic import() syntax is officially a part of ECMAScript 2020 specification. Hovewer to use this syntax in prior language versions you still need to bundle your code with Webpack.
+> The dynamic import() syntax is officially a part of ECMAScript 2020 specification. However to use this syntax in prior language versions you still need to bundle your code with Webpack.
 
 When Webpack comes across this syntax, it automatically starts code-splitting your app.
 


### PR DESCRIPTION
## Summary

`import()` syntax is officially a part of ES2020 so this note can be refined.

https://github.com/tc39/proposal-dynamic-import

## Test plan

n/a
