### PR TITLE
added option to exclude chunk from extractor

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -129,7 +129,9 @@ function createLoadable({
           // So we can require now the module synchronously
           this.loadSync()
 
-          props.__chunkExtractor.addChunk(ctor.chunkName(props))
+          if (!options.excludeChunkFromExtractor) {
+            props.__chunkExtractor.addChunk(ctor.chunkName(props))
+          }
           return
         }
 


### PR DESCRIPTION
## Summary

Motivation for this PR is to be able to completely exclude the chunk from loading if in case we would like to do performance optimizations.

For example:
- we would like to only render a component statically and therefore the additional JS is not needed.
- we would like to defer the loading of the chunk to go in line with our lazy-render so that it is never loaded initially if it isn't needed.

Please let me know if there could be a better naming, or what I need to do next to get this in.

See this working animation for the 2nd point:

## Test plan
![ezgif com-video-to-gif-4](https://user-images.githubusercontent.com/64774276/115746943-14d6ad00-a395-11eb-8621-d07d64126630.gif)

```
// loadable.js
if (!options.excludeChunkFromExtractor) {
  props.__chunkExtractor.addChunk(ctor.chunkName(props));
}

// component
const LazyFooter = loadable(() => import('./CmsFooter/CmsFooter'), {
  excludeChunkFromExtractor: true,
})
```
