### PR TITLE
feat: add stats option to webpack plugin

### DIFF
--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -11,35 +11,45 @@ class LoadablePlugin {
     writeToDisk,
     outputAsset = true,
     chunkLoadingGlobal = '__LOADABLE_LOADED_CHUNKS__',
+    stats,
   } = {}) {
-    this.opts = { filename, writeToDisk, outputAsset, path, chunkLoadingGlobal }
+    this.opts = {
+      filename,
+      writeToDisk,
+      outputAsset,
+      path,
+      chunkLoadingGlobal,
+      stats,
+    }
 
     // The Webpack compiler instance
     this.compiler = null
   }
 
   handleEmit = compilation => {
-    const stats = compilation.getStats().toJson({
-      all: false,
-      assets: true,
-      chunks: false,
-      chunkGroups: true,
-      chunkGroupChildren: true,
-      hash: true,
-      ids: true,
-      outputPath: true,
-      publicPath: true,
-    })
+    const stats = compilation.getStats().toJson(
+      this.opts.stats || {
+        all: false,
+        assets: true,
+        chunks: false,
+        chunkGroups: true,
+        chunkGroupChildren: true,
+        hash: true,
+        ids: true,
+        outputPath: true,
+        publicPath: true,
+      },
+    )
 
     stats.generator = 'loadable-components'
 
     // we don't need all chunk information, only a type
-    stats.chunks = [...compilation.chunks].map((chunk) => {
+    stats.chunks = [...compilation.chunks].map(chunk => {
       return {
         id: chunk.id,
         files: [...chunk.files],
-      };
-    });
+      }
+    })
 
     const result = JSON.stringify(stats, null, 2)
 

--- a/website/src/pages/docs/api-loadable-webpack-plugin.mdx
+++ b/website/src/pages/docs/api-loadable-webpack-plugin.mdx
@@ -17,10 +17,14 @@ Create a webpack loadable plugin.
 | `options.outputAsset`          | Always write stats file to the `output.path` directory. Defaults to `true`                   |
 | `options.writeToDisk`          | Accepts `boolean` or `object`. Always write stats file to disk. Default to `false`.          |
 | `options.writeToDisk.filename` | Write assets to disk at given `filename` location                                            |
-| `options.chunkLoadingGlobal`   | Overrides Webpack's `chunkLoadingGlobal` allowing multiple Webpack runtimes on the same page |
+| `options.chunkLoadingGlobal`   | Overrides webpack's `chunkLoadingGlobal` allowing multiple webpack runtimes on the same page |
+| `options.stats`                | Configure the [stats][wp-stats] to be output by webpack. Find the defaults [here][lc-stats]. |
 
 ```js
 new LoadablePlugin({ filename: 'stats.json', writeToDisk: true })
 ```
 
 > Writing file to disk can be useful if you are using `razzle` or `webpack-dev-server`.
+
+[wp-stats]: https://webpack.js.org/configuration/stats/
+[lc-stats]: https://github.com/gregberge/loadable-components/blob/main/packages/webpack-plugin/src/index.js#L23-L43


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Fix #770 as per [my suggestion](https://github.com/gregberge/loadable-components/issues/770#issuecomment-847797995).

## Test plan

1. Use plugin as before. Output should be identical.
2. Use plugin while passing custom `stats` options. The generated stats JSON file matches those options.