### PR TITLE
fix: add cachedAssets to stats options

### DIFF
--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -22,6 +22,7 @@ class LoadablePlugin {
     const stats = compilation.getStats().toJson({
       all: false,
       assets: true,
+      cachedAssets: true,
       chunks: false,
       chunkGroups: true,
       chunkGroupChildren: true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Fixes #770 by setting `cachedAssets: true`.

## Test plan

Run a webpack build using the plugin. Cached assets are found in the generated stats JSON file.