### PR TITLE
Added getScriptTagsByChunks and getScriptElementsByChunks

### DIFF
--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -126,6 +126,71 @@ describe('ChunkExtrator', () => {
     })
   })
 
+  describe('#getScriptTagsByChunks', () => {
+    it('should return main script tag without chunk', () => {
+      expect(extractor.getScriptTagsByChunks()).toMatchInlineSnapshot(`
+        "<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\">[]</script><script id=\\"__LOADABLE_REQUIRED_CHUNKS___ext\\" type=\\"application/json\\">{\\"namedChunks\\":[]}</script>
+        <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>"
+      `)
+    })
+
+    it('should return main script tag without chunk with namespaced required chunks id', () => {
+      const testExtractor = new ChunkExtractor({
+        namespace: 'testapp',
+        stats,
+        outputPath: path.resolve(__dirname, '../__fixtures__'),
+      })
+      expect(testExtractor.getScriptTagsByChunks()).toMatchInlineSnapshot(`
+        "<script id=\\"testapp__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\">[]</script><script id=\\"testapp__LOADABLE_REQUIRED_CHUNKS___ext\\" type=\\"application/json\\">{\\"namedChunks\\":[]}</script>
+        <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>"
+      `)
+    })
+
+    it('should return other chunks if referenced', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getScriptTagsByChunks()).toMatchInlineSnapshot(`
+        "<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\">[\\"letters-A\\"]</script><script id=\\"__LOADABLE_REQUIRED_CHUNKS___ext\\" type=\\"application/json\\">{\\"namedChunks\\":[\\"letters-A\\"]}</script>
+        <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\"></script>
+        <script async data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\"></script>"
+      `)
+    })
+
+    it('should return only the specified chunks', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getScriptTagsByChunks({ includedChunks: 'letters-A' }))
+        .toMatchInlineSnapshot(`
+        "<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\">[\\"letters-A\\"]</script><script id=\\"__LOADABLE_REQUIRED_CHUNKS___ext\\" type=\\"application/json\\">{\\"namedChunks\\":[\\"letters-A\\"]}</script>
+        <script async data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\"></script>"
+      `)
+    })
+
+    it('should add extra props if specified - object argument', () => {
+      extractor.addChunk('letters-A')
+      expect(
+        extractor.getScriptTagsByChunks({ extraProps: { nonce: 'testnonce' } }),
+      ).toMatchInlineSnapshot(`
+        "<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\" nonce=\\"testnonce\\">[\\"letters-A\\"]</script><script id=\\"__LOADABLE_REQUIRED_CHUNKS___ext\\" type=\\"application/json\\" nonce=\\"testnonce\\">{\\"namedChunks\\":[\\"letters-A\\"]}</script>
+        <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\" nonce=\\"testnonce\\"></script>
+        <script async data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\" nonce=\\"testnonce\\"></script>"
+      `)
+    })
+
+    it('should add extra props if specified - function argument', () => {
+      extractor.addChunk('letters-A')
+      expect(
+        extractor.getScriptTagsByChunks({
+          extraProps: asset => {
+            return { nonce: asset ? asset.chunk : 'anonymous' }
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        "<script id=\\"__LOADABLE_REQUIRED_CHUNKS__\\" type=\\"application/json\\" nonce=\\"anonymous\\">[\\"letters-A\\"]</script><script id=\\"__LOADABLE_REQUIRED_CHUNKS___ext\\" type=\\"application/json\\" nonce=\\"anonymous\\">{\\"namedChunks\\":[\\"letters-A\\"]}</script>
+        <script async data-chunk=\\"main\\" src=\\"/dist/node/main.js\\" nonce=\\"main\\"></script>
+        <script async data-chunk=\\"letters-A\\" src=\\"/dist/node/letters-A.js\\" nonce=\\"letters-A\\"></script>"
+      `)
+    })
+  })
+
   describe('#getScriptElements', () => {
     it('should return main script tag without chunk with namespaced id for loadable chunks', () => {
       const testExtractor = new ChunkExtractor({
@@ -358,6 +423,305 @@ describe('ChunkExtrator', () => {
       })
 
       expect(testExtractor.getScriptElements()).toMatchInlineSnapshot(`
+        Array [
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "[]",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS__"
+            type="application/json"
+          />,
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "{\\"namedChunks\\":[]}",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS___ext"
+            type="application/json"
+          />,
+          <script
+            async={true}
+            data-chunk="main"
+            src="https://cdn.example.org/v1.1.0/main.js"
+          />,
+        ]
+      `)
+    })
+  })
+
+  describe('#getScriptElementsByChunks', () => {
+    it('should return main script tag without chunk with namespaced id for loadable chunks', () => {
+      const testExtractor = new ChunkExtractor({
+        namespace: 'testapp',
+        stats,
+        outputPath: path.resolve(__dirname, '../__fixtures__'),
+      })
+      expect(testExtractor.getScriptElementsByChunks()).toMatchInlineSnapshot(`
+        Array [
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "[]",
+              }
+            }
+            id="testapp__LOADABLE_REQUIRED_CHUNKS__"
+            type="application/json"
+          />,
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "{\\"namedChunks\\":[]}",
+              }
+            }
+            id="testapp__LOADABLE_REQUIRED_CHUNKS___ext"
+            type="application/json"
+          />,
+          <script
+            async={true}
+            data-chunk="main"
+            src="/dist/node/main.js"
+          />,
+        ]
+      `)
+    })
+
+    it('should return main script tag without chunk', () => {
+      expect(extractor.getScriptElementsByChunks()).toMatchInlineSnapshot(`
+        Array [
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "[]",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS__"
+            type="application/json"
+          />,
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "{\\"namedChunks\\":[]}",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS___ext"
+            type="application/json"
+          />,
+          <script
+            async={true}
+            data-chunk="main"
+            src="/dist/node/main.js"
+          />,
+        ]
+      `)
+    })
+
+    it('should return other chunks if referenced', () => {
+      extractor.addChunk('letters-A')
+      expect(extractor.getScriptElementsByChunks()).toMatchInlineSnapshot(`
+        Array [
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "[\\"letters-A\\"]",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS__"
+            type="application/json"
+          />,
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "{\\"namedChunks\\":[\\"letters-A\\"]}",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS___ext"
+            type="application/json"
+          />,
+          <script
+            async={true}
+            data-chunk="main"
+            src="/dist/node/main.js"
+          />,
+          <script
+            async={true}
+            data-chunk="letters-A"
+            src="/dist/node/letters-A.js"
+          />,
+        ]
+      `)
+    })
+
+    it('should return the specified chunks', () => {
+      extractor.addChunk('letters-A')
+      expect(
+        extractor.getScriptElementsByChunks({ includedChunks: 'letters-A' }),
+      ).toMatchInlineSnapshot(`
+        Array [
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "[\\"letters-A\\"]",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS__"
+            type="application/json"
+          />,
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "{\\"namedChunks\\":[\\"letters-A\\"]}",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS___ext"
+            type="application/json"
+          />,
+          <script
+            async={true}
+            data-chunk="letters-A"
+            src="/dist/node/letters-A.js"
+          />,
+        ]
+      `)
+    })
+
+    // params not working
+    it.skip('should allow for query params in chunk names', () => {
+      extractor.addChunk('letters-E')
+      expect(extractor.getScriptElementsByChunks()).toMatchInlineSnapshot(`
+        Array [
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "[\\"letters-E\\"]",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS__"
+            type="application/json"
+          />,
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "{\\"namedChunks\\":[\\"letters-E\\"]}",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS___ext"
+            type="application/json"
+          />,
+          <script
+            async={true}
+            data-chunk="main"
+            src="/dist/node/main.js"
+          />,
+          <script
+            async={true}
+            data-chunk="letters-E"
+            src="/dist/node/letters-E.js?param"
+          />,
+        ]
+      `)
+    })
+
+    it('should add extra props if specified - object argument', () => {
+      extractor.addChunk('letters-A')
+      expect(
+        extractor.getScriptElementsByChunks({
+          extraProps: { nonce: 'testnonce' },
+        }),
+      ).toMatchInlineSnapshot(`
+        Array [
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "[\\"letters-A\\"]",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS__"
+            nonce="testnonce"
+            type="application/json"
+          />,
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "{\\"namedChunks\\":[\\"letters-A\\"]}",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS___ext"
+            nonce="testnonce"
+            type="application/json"
+          />,
+          <script
+            async={true}
+            data-chunk="main"
+            nonce="testnonce"
+            src="/dist/node/main.js"
+          />,
+          <script
+            async={true}
+            data-chunk="letters-A"
+            nonce="testnonce"
+            src="/dist/node/letters-A.js"
+          />,
+        ]
+      `)
+    })
+
+    it('should add extra props if specified - function argument', () => {
+      extractor.addChunk('letters-A')
+      expect(
+        extractor.getScriptElementsByChunks({
+          extraProps: asset => {
+            return { nonce: asset ? asset.chunk : 'anonymous' }
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        Array [
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "[\\"letters-A\\"]",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS__"
+            nonce="anonymous"
+            type="application/json"
+          />,
+          <script
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "{\\"namedChunks\\":[\\"letters-A\\"]}",
+              }
+            }
+            id="__LOADABLE_REQUIRED_CHUNKS___ext"
+            nonce="anonymous"
+            type="application/json"
+          />,
+          <script
+            async={true}
+            data-chunk="main"
+            nonce="main"
+            src="/dist/node/main.js"
+          />,
+          <script
+            async={true}
+            data-chunk="letters-A"
+            nonce="letters-A"
+            src="/dist/node/letters-A.js"
+          />,
+        ]
+      `)
+    })
+
+    it('should use publicPath from options', () => {
+      const testExtractor = new ChunkExtractor({
+        stats,
+        publicPath: 'https://cdn.example.org/v1.1.0/',
+        outputPath: path.resolve(__dirname, '../__fixtures__'),
+      })
+
+      expect(testExtractor.getScriptElementsByChunks()).toMatchInlineSnapshot(`
         Array [
           <script
             dangerouslySetInnerHTML={
@@ -655,7 +1019,7 @@ describe('ChunkExtrator', () => {
       expect(extractor.inputFileSystem.readFile).toHaveBeenCalledTimes(2)
       expect(data).toMatchInlineSnapshot(`
         "foo
-        
+
         foo
         "
       `)

--- a/website/src/pages/docs/api-loadable-server.mdx
+++ b/website/src/pages/docs/api-loadable-server.mdx
@@ -69,6 +69,18 @@ Get scripts as a string of `<script>` tags.
 const body = `<body><div id="root">${html}</div>${chunkExtractor.getScriptTags()}</body>`
 ```
 
+## chunkExtractor.getScriptTagsByChunks
+
+Get scripts as a string of `<script>` tags limited to only the chunks that you have specified.
+
+| Arguments                                                          | Description                                                                                                                                                                            |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| { extraProps: `attributes` or `attrFn`, includedChunks: string[] } | `extraProps` attributes added to script tags, or a function that receives a `chunk` and returns the attributes. `includedChunks` filter generated tags to only those within this list. |
+
+```js
+const body = `<body><div id="root">${html}</div>${chunkExtractor.getScriptTagsByChunks({ includedChunks: ['chunk-name'] })}</body>`
+```
+
 ## chunkExtractor.getScriptElements
 
 Get scripts as an array of React `<script>` elements.
@@ -82,6 +94,23 @@ const body = renderToString(
   <body>
     <div id="root" dangerouslySetInnerHtml={{ __html: html }} />
     {chunkExtractor.getScriptElements()}
+  </body>,
+)
+```
+
+## chunkExtractor.getScriptElementsByChunks
+
+Get scripts as an array of React `<script>` elements limited to only the chunks that you have specified.
+
+| Arguments                                                          | Description                                                                                                                                                                                    |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| { extraProps: `attributes` or `attrFn`, includedChunks: string[] } | `extraProps` attributes added to script elements, or a function that receives a `chunk` and returns the attributes. `includedChunks` filter generated elements to only those within this list. |
+
+```js
+const body = renderToString(
+  <body>
+    <div id="root" dangerouslySetInnerHtml={{ __html: html }} />
+    {chunkExtractor.getScriptElementsByChunks({ includedChunks: ['chunk-name'] })}
   </body>,
 )
 ```


### PR DESCRIPTION
## Summary

This PR aims to solve #769 by providing an API where you can generate script tags/elements for a specific chunk excluding other non-specified chunks. 

## Test plan

1. All other APIs will work as before, they remain unchanged.
2. For the new APIs, the arguments is now a single object with optional properties. 
  - `extraProps` works exactly as before either an object or a function
  - `includedChunks` allows you to specify which chunks you want to generate tags/elements for
3. You can see an example usage in the specs that I've added, hopefully those are enough to demonstrate how this works

## Notes

I'm open to discussion with the API design here, let me know if there's anything that you would like changed or designer another way.
