### PR TITLE
Use prefetch, not preload for better TTI

### DIFF
--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -254,7 +254,8 @@ class ChunkExtractor {
             filename,
             chunk,
             type: 'mainAsset',
-            linkType: 'preload',
+            // prefetch vs. preload gives much better TTI
+            linkType: 'prefetch',
           }),
         )
         .filter(isValidChunkAsset)
@@ -462,9 +463,10 @@ class ChunkExtractor {
   getPreAssets() {
     const mainAssets = this.getMainAssets()
     const chunks = [...this.entrypoints, ...this.chunks]
-    const preloadAssets = this.getChunkChildAssets(chunks, 'preload')
+    // No need to preload and prefetch the chunks
+    // const preloadAssets = this.getChunkChildAssets(chunks, 'preload')
     const prefetchAssets = this.getChunkChildAssets(chunks, 'prefetch')
-    return [...mainAssets, ...preloadAssets, ...prefetchAssets].sort(a =>
+    return [...mainAssets, ...prefetchAssets].sort(a =>
       a.scriptType === 'style' ? -1 : 0,
     )
   }


### PR DESCRIPTION
Addresses #720 

## Summary
The commit changes link tags to use `prefetch` only.

Why? The browser starts downloading JS bundles sooner but with the
lowest priority. The priority for JS bundles becomes lower than HTML
images and CSS files so the browser can download these files with almost
the same speed as before. But JS bundles are downloading faster.

### link prefetch vs. link preload

Prefetching will give the browser freedom to choose the best timing to
load the bundles by giving Js bundles the lowest priority. On the other
hand, preloading will give JS bundles the highest priority and will
begin by loading them early in the page lifecycle, even before HTML has
finished loading, and the browser's main rendering machinery kicks in.
So preload will block the main content of the page to load until Js
bundles are entirely loaded, Thus, result in significant regressions in
TTI and LCP.

link prefetch, on the other hand, doesn't compete with HTML loading
because it has a lower priority.

With no link tags, images and JS bundles had equal (low) priority before
adding link prefetch tags. So, the browser will suboptimally decide when
to download each one. Typically, the browser will first download images
based on the HTML tags and then begin downloading the main JS bundles.

After adding link prefetch tags, images have a low priority but the main
JS bundles have the lowest priority. So, the browser can optimally
decide when to download the JS bundles. Thus, we find that the browser
downloads the JS bundles at the beginning with the images. Then, it
stops downloading the main Js bundles and decides to focus all the
network resources on downloading images until they finish up, then it
continues downloading the Js bundles. Thus, that results in lowering the
TTI and increasing the interactivity of the website.


## Test plan

TBD