### PR TITLE
Fix getInlineStyleTags/Elements docs.

### DIFF
--- a/website/src/pages/docs/api-loadable-server.mdx
+++ b/website/src/pages/docs/api-loadable-server.mdx
@@ -132,7 +132,7 @@ const head = renderToString(<head>{chunkExtractor.getStyleElements()}</head>)
 
 ## chunkExtractor.getInlineStyleTags
 
-Get inline style links as a string of `<link>` tags (returns a promise).
+Get inline styles as a string of `<style>` tags (returns a promise).
 
 | Arguments                | Description                                                                                                |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------- |
@@ -147,7 +147,7 @@ chunkExtractor.getInlineStyleTags()
 
 ## chunkExtractor.getInlineStyleElements
 
-Get inline style links as an array of React `<link>` elements (returns a promise).
+Get inline style tags as an array of React `<style>` elements (returns a promise).
 
 | Arguments                | Description                                                                                                    |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------- |

--- a/website/src/pages/docs/api-loadable-server.mdx
+++ b/website/src/pages/docs/api-loadable-server.mdx
@@ -147,7 +147,7 @@ chunkExtractor.getInlineStyleTags()
 
 ## chunkExtractor.getInlineStyleElements
 
-Get inline style tags as an array of React `<style>` elements (returns a promise).
+Get inline styles as an array of React `<style>` elements (returns a promise).
 
 | Arguments                | Description                                                                                                    |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

These docs disagree with their implementation. The docs mention `link` tags but the implementation uses `style` tags. The implementation seems obviously correct so I assume it's the docs that need fixing.

Here is `getInlineStyleTags` using `style` tags as expected:
https://github.com/gregberge/loadable-components/blob/629c80e42eea605a32dafd7b52faf3140e1aab28/packages/server/src/ChunkExtractor.test.js#L463-L479

Here is `getInlineStyleElements` using `style` tags as expected:
https://github.com/gregberge/loadable-components/blob/629c80e42eea605a32dafd7b52faf3140e1aab28/packages/server/src/ChunkExtractor.test.js#L622-L650

## Test plan

N/A
