### PR TITLE
Cache promise on load/preload

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -343,10 +343,13 @@ function createLoadable({
 
     // In future, preload could use `<link rel="preload">`
     Loadable.preload = props => {
-      ctor.requireAsync(props)
+      cache[getCacheKey()] = ctor.requireAsync(props);
     }
 
-    Loadable.load = props => ctor.requireAsync(props)
+    Loadable.load = props => {
+      cache[getCacheKey()] = ctor.requireAsync(props);
+      return cache[getCacheKey()];
+    }
 
     return Loadable
   }


### PR DESCRIPTION
## Summary

I guess the cache in `preload` and `load` methods is not used on purpose but I was curious whether you'd be interested in this change, maybe under an option or a different static method `cache`.

The use case for me is that I did try to prefetch pages on link hover, but after transiting to the prefetched page I saw a blink of white page in between the route transitions, even though I was blocking the transition until the module was fetched.

This only happened on the first transition, subsequent transitions to the cached pages didn't have the blink anymore, which lead me to this change.