### PR TITLE
fix: Clear correct cache when compiling with Webpack

### DIFF
--- a/packages/server/src/util.js
+++ b/packages/server/src/util.js
@@ -1,5 +1,11 @@
+// Use __non_webpack_require__ to prevent Webpack from compiling it
+// when the server-side code is compiled with Webpack
+// eslint-disable-next-line camelcase, no-undef, global-require, import/no-dynamic-require, no-eval
+const getRequire = () => typeof __non_webpack_require__ !== 'undefined' ? __non_webpack_require__ : eval('require');
+
 export const clearModuleCache = moduleName => {
-  const m = require.cache[moduleName]
+  const { cache } = getRequire();
+  const m = cache[moduleName]
   if (m) {
     // remove self from own parents
     if (m.parent && m.parent.children) {
@@ -13,7 +19,7 @@ export const clearModuleCache = moduleName => {
         }
       })
     }
-    delete require.cache[moduleName]
+    delete cache[moduleName]
   }
 }
 
@@ -22,16 +28,7 @@ export const smartRequire = modulePath => {
     clearModuleCache(modulePath)
   }
 
-  // Use __non_webpack_require__ to prevent Webpack from compiling it
-  // when the server-side code is compiled with Webpack
-  // eslint-disable-next-line camelcase
-  if (typeof __non_webpack_require__ !== 'undefined') {
-    // eslint-disable-next-line no-undef
-    return __non_webpack_require__(modulePath)
-  }
-
-  // eslint-disable-next-line global-require, import/no-dynamic-require, no-eval
-  return eval('require')(modulePath)
+  return getRequire(modulePath)
 }
 
 export const joinURLPath = (publicPath, filename) => {

--- a/packages/server/src/util.js
+++ b/packages/server/src/util.js
@@ -28,7 +28,7 @@ export const smartRequire = modulePath => {
     clearModuleCache(modulePath)
   }
 
-  return getRequire(modulePath)
+  return getRequire()(modulePath)
 }
 
 export const joinURLPath = (publicPath, filename) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Using `module.hot` is forcing me to use Webpack `HotModuleReplacementPlugin` and excluding `@loadable/server` from `nodeExternal()` so that `module.hot` is present. (8f10896058cdfd542c2aca1a982c2e14b1d9707a)

Then `__non_webpack_require__` is used in `smartRequire` (https://github.com/gregberge/loadable-components/blob/main/packages/server/src/util.js#L30) but `clearModuleCache` is clearing cache from `require` not from `__non_webpack_require__`.

This PR should fix this problem.

## Test plan

See #821
