### PR TITLE
 Add note on order of calls when server-side rendering

### DIFF
--- a/website/src/pages/docs/server-side-rendering.mdx
+++ b/website/src/pages/docs/server-side-rendering.mdx
@@ -56,6 +56,10 @@ const jsx = extractor.collectChunks(<YourApp />)
 // Render your application
 const html = renderToString(jsx)
 
+/* `renderToString` must be called before `getScriptTags`, `getLinkTags`
+ * and `getStyleTags`.
+ */
+
 // You can now collect your script tags
 const scriptTags = extractor.getScriptTags() // or extractor.getScriptElements();
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The docs on server-side rendering could be interpreted incorrectly and one can miss the important fact that the order of calls to `ChunkExtractor` matters alot. Specifically that you have to render the app _before_ collecting script tags.

This adds a note that explicitly states the importance of the call order. I personally spent way too many hours debugging why my app was not hydrating properly, and without any errors or docs on this matter, it's quite easy to miss this important fact.

There are also a number of issues where the cause is this exact configuration issue. Hopefully this will help alleviate any similar mistakes in the future.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
