### PR TITLE
feat: add transformStats option

### DIFF
--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -11,15 +11,23 @@ class LoadablePlugin {
     writeToDisk,
     outputAsset = true,
     chunkLoadingGlobal = '__LOADABLE_LOADED_CHUNKS__',
+    transformStats,
   } = {}) {
-    this.opts = { filename, writeToDisk, outputAsset, path, chunkLoadingGlobal }
+    this.opts = {
+      filename,
+      writeToDisk,
+      outputAsset,
+      path,
+      chunkLoadingGlobal,
+      transformStats,
+    }
 
     // The Webpack compiler instance
     this.compiler = null
   }
 
   handleEmit = compilation => {
-    const stats = compilation.getStats().toJson({
+    let stats = compilation.getStats().toJson({
       all: false,
       assets: true,
       cachedAssets: true,
@@ -54,6 +62,10 @@ class LoadablePlugin {
         }
       })
     })
+
+    if (this.opts.transformStats) {
+      stats = this.opts.transformStats(stats, compilation)
+    }
 
     const result = JSON.stringify(stats, null, 2)
 

--- a/website/src/pages/docs/api-loadable-webpack-plugin.mdx
+++ b/website/src/pages/docs/api-loadable-webpack-plugin.mdx
@@ -10,14 +10,15 @@ order: 30
 
 Create a webpack loadable plugin.
 
-| Arguments                      | Description                                                                                  |
-| ------------------------------ | -------------------------------------------------------------------------------------------- |
-| `options`                      | Optional options                                                                             |
-| `options.filename`             | Stats filename (default to `loadable-stats.json`)                                            |
-| `options.outputAsset`          | Always write stats file to the `output.path` directory. Defaults to `true`                   |
-| `options.writeToDisk`          | Accepts `boolean` or `object`. Always write stats file to disk. Default to `false`.          |
-| `options.writeToDisk.filename` | Write assets to disk at given `filename` location                                            |
-| `options.chunkLoadingGlobal`   | Overrides Webpack's `chunkLoadingGlobal` allowing multiple Webpack runtimes on the same page |
+| Arguments                      | Description                                                                                                          |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `options`                      | Optional options                                                                                                     |
+| `options.filename`             | Stats filename (default to `loadable-stats.json`)                                                                    |
+| `options.outputAsset`          | Always write stats file to the `output.path` directory. Defaults to `true`                                           |
+| `options.writeToDisk`          | Accepts `boolean` or `object`. Always write stats file to disk. Default to `false`.                                  |
+| `options.writeToDisk.filename` | Write assets to disk at given `filename` location                                                                    |
+| `options.chunkLoadingGlobal`   | Overrides Webpack's `chunkLoadingGlobal` allowing multiple Webpack runtimes on the same page                         |
+| `options.transformStats`       | Function for additional trasformations of `stats` object. Should return `stats` object. Args: `stats`, `compilation` |
 
 ```js
 new LoadablePlugin({ filename: 'stats.json', writeToDisk: true })


### PR DESCRIPTION
## Summary
Add `transformStats` option to webpack plugin. 
Motivation: sometimes you need to add additional info to loadable stats json or remove some fields. For example if you don't use `extractor.requireEntrypoint` method you can remove `stats` field and reduce stats file size several times.

