### PR TITLE
WIP: Fix SSR and CSR for federated modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules/
 dist/
 lib/

--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/loadable.cjs.js": {
-    "bundled": 16760,
-    "minified": 7400,
-    "gzipped": 2617
+    "bundled": 18120,
+    "minified": 8069,
+    "gzipped": 2819
   },
   "dist/loadable.esm.js": {
-    "bundled": 16381,
-    "minified": 7096,
-    "gzipped": 2550,
+    "bundled": 17741,
+    "minified": 7765,
+    "gzipped": 2747,
     "treeshaked": {
       "rollup": {
         "code": 276,
         "import_statements": 276
       },
       "webpack": {
-        "code": 5969
+        "code": 6096
       }
     }
   }

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -5,7 +5,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics'
 import { invariant } from './util'
 import Context from './Context'
 import { LOADABLE_SHARED } from './shared'
-import { register } from './loadableModulesMap';
+import { register } from './federatedResolver';
 
 const STATUS_PENDING = 'PENDING'
 const STATUS_RESOLVED = 'RESOLVED'

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -5,6 +5,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics'
 import { invariant } from './util'
 import Context from './Context'
 import { LOADABLE_SHARED } from './shared'
+import { register } from './loadableModulesMap';
 
 const STATUS_PENDING = 'PENDING'
 const STATUS_RESOLVED = 'RESOLVED'
@@ -46,8 +47,9 @@ function createLoadable({
   onLoad,
 }) {
   function loadable(loadableConstructor, options = {}) {
-    const ctor = resolveConstructor(loadableConstructor)
     const cache = {}
+    const ctor = resolveConstructor(loadableConstructor)
+    register(ctor);
 
     /**
      * Cachekey represents the component to be loaded

--- a/packages/component/src/federatedResolver.js
+++ b/packages/component/src/federatedResolver.js
@@ -3,20 +3,20 @@ const localModuleNames = [];
 
 const isFederated = (loadableCtor) => loadableCtor.resolve().indexOf('webpack/container/remote') === 0;
 
-export const register = (loadableCtor) => {
+export function register(loadableCtor) {
   const moduleName = loadableCtor.chunkName();
   if (isFederated(loadableCtor)) {
     federatedModuleMap[moduleName] = loadableCtor.importAsync;
   } else {
     localModuleNames.push(moduleName);
   }
-};
+}
 
 /**
  * Calls importAsync for all the modules listed in moduleNames
  * Resolves after modules are loaded
  */
-export const resolveNamedFederatedModules = (moduleNames) => {
+export function resolveNamedFederatedModules(moduleNames) {
   const federatedModules = moduleNames
     .filter((name) => !localModuleNames.includes(name))
     .map((name) => federatedModuleMap[name]);
@@ -25,12 +25,15 @@ export const resolveNamedFederatedModules = (moduleNames) => {
   federatedModuleMap = {};
 
   return Promise.all(federatedModules.map((loader) => loader()));
-};
+}
 
 
 /**
  * Preload all the existing federated modules, to be used on the server (we don't have loadable required chunks on SSR)
  */
-export const resolveAllFederatedModules = () => resolveNamedFederatedModules(Object.keys(federatedModuleMap))
-  // repeat if more modules are discovered during preloading
-  .then(Object.keys(federatedModuleMap).length ? resolveAllFederatedModules() : undefined);
+export function resolveAllFederatedModules() {
+  const moduleNames = Object.keys(federatedModuleMap);
+  return moduleNames.length ? resolveNamedFederatedModules(moduleNames)
+    // repeat if more modules are discovered during preloading
+    .then(resolveAllFederatedModules) : Promise.resolve();
+}

--- a/packages/component/src/federatedResolver.js
+++ b/packages/component/src/federatedResolver.js
@@ -16,7 +16,7 @@ export const register = (loadableCtor) => {
  * Calls importAsync for all the modules listed in moduleNames
  * Resolves after modules are loaded
  */
-export const preload = (moduleNames) => {
+export const resolveNamedFederatedModules = (moduleNames) => {
   const federatedModules = moduleNames
     .filter((name) => !localModuleNames.includes(name))
     .map((name) => federatedModuleMap[name]);
@@ -29,8 +29,8 @@ export const preload = (moduleNames) => {
 
 
 /**
- * Preload all the existing federated modules, to be on the server (we don't have loadable required chunks on SSR)
+ * Preload all the existing federated modules, to be used on the server (we don't have loadable required chunks on SSR)
  */
-export const preloadAll = () => preload(Object.keys(federatedModuleMap))
+export const resolveAllFederatedModules = () => resolveNamedFederatedModules(Object.keys(federatedModuleMap))
   // repeat if more modules are discovered during preloading
-  .then(Object.keys(federatedModuleMap).length ? preloadAll() : undefined);
+  .then(Object.keys(federatedModuleMap).length ? resolveAllFederatedModules() : undefined);

--- a/packages/component/src/loadableModulesMap.js
+++ b/packages/component/src/loadableModulesMap.js
@@ -1,0 +1,36 @@
+let federatedModuleMap = {};
+const localModuleNames = [];
+
+const isFederated = (loadableCtor) => loadableCtor.resolve().indexOf('webpack/container/remote') === 0;
+
+export const register = (loadableCtor) => {
+  const moduleName = loadableCtor.chunkName();
+  if (isFederated(loadableCtor)) {
+    federatedModuleMap[moduleName] = loadableCtor.importAsync;
+  } else {
+    localModuleNames.push(moduleName);
+  }
+};
+
+/**
+ * Calls importAsync for all the modules listed in moduleNames
+ * Resolves after modules are loaded
+ */
+export const preload = (moduleNames) => {
+  const federatedModules = moduleNames
+    .filter((name) => !localModuleNames.includes(name))
+    .map((name) => federatedModuleMap[name]);
+
+  // only need to preload module once
+  federatedModuleMap = {};
+
+  return Promise.all(federatedModules.map((loader) => loader()));
+};
+
+
+/**
+ * Preload all the existing federated modules, to be on the server (we don't have loadable required chunks on SSR)
+ */
+export const preloadAll = () => preload(Object.keys(federatedModuleMap))
+  // repeat if more modules are discovered during preloading
+  .then(Object.keys(federatedModuleMap).length ? preloadAll() : undefined);

--- a/packages/component/src/loadableReady.js
+++ b/packages/component/src/loadableReady.js
@@ -3,7 +3,7 @@
 import { warn } from './util'
 import { getRequiredChunkKey } from './sharedInternals'
 import { LOADABLE_SHARED } from './shared'
-import { preload, preloadAll } from './loadableModulesMap';
+import { resolveNamedFederatedModules, resolveAllFederatedModules } from './federatedResolver';
 
 const BROWSER = typeof window !== 'undefined'
 
@@ -12,7 +12,7 @@ export default function loadableReady(
   { namespace = '', chunkLoadingGlobal = '__LOADABLE_LOADED_CHUNKS__' } = {},
 ) {
   if (!BROWSER) {
-    return preloadAll().then(done);
+    return resolveAllFederatedModules().then(done);
   }
 
   let requiredChunks = null
@@ -70,6 +70,6 @@ export default function loadableReady(
     }
 
     checkReadyState()
-  }).then(() => preload(namedChunks))
+  }).then(() => resolveNamedFederatedModules(namedChunks))
     .then(done);
 }

--- a/packages/webpack-plugin/src/federatedStatsCollector.js
+++ b/packages/webpack-plugin/src/federatedStatsCollector.js
@@ -1,0 +1,75 @@
+
+const extractSharedModuleOpts = (moduleIdentifier) => {
+  const [
+    _issuerType, _shareScope, _shareKey, semver, _strictVersion, _fullPath, singleton, eager
+  ] = moduleIdentifier.split(/(?<!\|)\|(?!\|)/);
+
+  return {
+    semver: semver === 'undefined' ? '*' : semver,
+    singleton: singleton === 'true',
+    eager: eager === 'true',
+  };
+}
+
+const isSharedModule = (moduleIdentifier) => moduleIdentifier.indexOf(`webpack/sharing/`) === 0
+
+const collectSharedModuleConsumptionStats = (modules = []) => {
+  const sharedConsumes = {};
+  const sharedModules = {};
+
+  modules.forEach((module) => {
+    (module.reasons || []).forEach((reason) => {
+      switch (reason.type) {
+        // sync usage
+        case 'cjs require':
+        case 'cjs full require':
+        case 'cjs export require':
+        case 'harmony import specifier':
+        case 'harmony side effect evaluation':
+          if (isSharedModule(module.id)) {
+            module.chunks.forEach((chunkId) => {
+              sharedConsumes[chunkId] = sharedConsumes[chunkId] || [];
+              if (sharedConsumes[chunkId].indexOf(module.id) === -1) {
+                sharedConsumes[chunkId].push(module.id);
+              }
+            });
+          }
+          break;
+        // internal shared usage
+        case 'consume shared fallback':
+          /** Probably always true for this reason.type, but better safe than sorry */
+          if (isSharedModule(reason.moduleId)) {
+            sharedModules[reason.moduleId] = {
+              chunks: module.chunks,
+              ...extractSharedModuleOpts(reason.moduleIdentifier),
+              lib: reason.userRequest,
+            };
+          }
+          break;
+
+        // NOTE: Other reason types are probably going to be used in the future
+        // async usage
+        case 'import()':
+        // external shared usage
+        case 'provide module for shared':
+        // entry point definition
+        case 'container entry':
+        case 'entry':
+        // external shared exposes binding
+        case 'container exposed':
+        // entrypoint to external binding
+        case 'provide shared module':
+          break;
+      }
+    });
+  });
+  return {
+    sharedConsumes,
+    sharedModules,
+  };
+};
+
+
+module.exports = {
+  collectSharedModuleConsumptionStats,
+};


### PR DESCRIPTION
## Changes
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
- add loadableModulesMap to register and preload modules for client- and server-side rendering;
- loadableReady now calls importAsync for all the federated modules (listed in named section) and only resolves once that import finishes;
- loadableReady now runs on the server, but instead of preloading required modules, it preloads all the federated modules. During that preload, new federated modules may be discovered, so the process continues till the entire chain is required;

## Summary
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes SSR and CSR for ModuleFederation.
For details see: https://github.com/gregberge/loadable-components/issues/640

There are currently issues both server- and client-side:
- loadable currently fails server-side unless static import for each of the federated modules exists. That hack allows wmf to preload these modules during async bootstrap.
- loadableReady call on the client currently breaks on the client, because requireSync expects loadable chunks to be available on the page. Example currently hydrate the page without loadableReady, which results in loadable running in async mode, and can cause side effects, if modules aren't available on the page;

This PR is meant to fix both these problems,

## Test plan
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Unsolved major issues:
- [ ] Eager static imports behind async boundary are not added to loadable manifest
- [ ] No way to mark async boundary import as required loadable dependency

Minor issues that need to be addressed:
- [x] Need to rebuild loadable and see if it works, might be some side effects;
- [ ] { ssr: false } flag might not be supported;
- [ ] There is no warning for not providing federated chunks synchronously;
- [ ] Only tested for webpack target: 'web' | 'node';
- [ ] Not tested with fully dynamic components (they are probably not going to be supported);
- [ ] Not tested with loadable.lib;
- [ ] LoadableReady used to support synchronous call, now its promise-based. We might want to make it work synchronously again for backwards compatibility;
- [ ] Check if this is working with production builds;
- [ ] Check if client-side only required components are preloaded;