### PR TITLE
feat: allow overriding stats for webpack-plugin

### DIFF
--- a/packages/webpack-plugin/src/index.js
+++ b/packages/webpack-plugin/src/index.js
@@ -11,8 +11,16 @@ class LoadablePlugin {
     writeToDisk,
     outputAsset = true,
     chunkLoadingGlobal = '__LOADABLE_LOADED_CHUNKS__',
+    loadableStatsFileOptions = {},
   } = {}) {
-    this.opts = { filename, writeToDisk, outputAsset, path, chunkLoadingGlobal }
+    this.opts = {
+      filename,
+      writeToDisk,
+      outputAsset,
+      path,
+      chunkLoadingGlobal,
+      loadableStatsFileOptions,
+    }
 
     // The Webpack compiler instance
     this.compiler = null
@@ -30,6 +38,13 @@ class LoadablePlugin {
       ids: true,
       outputPath: true,
       publicPath: true,
+      /**
+       * There are situations where an end user may want to override the output
+       * of the stats file. For example, some build systems require reproducible output
+       * and some of the paths and ids can be dynamic. Not outputting them to
+       * the stats file can help to create a more hermetic output
+       */
+      ...this.opts.loadableStatsFileOptions
     })
 
     stats.generator = 'loadable-components'

--- a/website/src/pages/docs/api-loadable-webpack-plugin.mdx
+++ b/website/src/pages/docs/api-loadable-webpack-plugin.mdx
@@ -10,17 +10,22 @@ order: 30
 
 Create a webpack loadable plugin.
 
-| Arguments                      | Description                                                                                  |
-| ------------------------------ | -------------------------------------------------------------------------------------------- |
-| `options`                      | Optional options                                                                             |
-| `options.filename`             | Stats filename (default to `loadable-stats.json`)                                            |
-| `options.outputAsset`          | Always write stats file to the `output.path` directory. Defaults to `true`                   |
-| `options.writeToDisk`          | Accepts `boolean` or `object`. Always write stats file to disk. Default to `false`.          |
-| `options.writeToDisk.filename` | Write assets to disk at given `filename` location                                            |
-| `options.chunkLoadingGlobal`   | Overrides Webpack's `chunkLoadingGlobal` allowing multiple Webpack runtimes on the same page |
+| Arguments                          | Description                                                                                  |
+| ---------------------------------- | -------------------------------------------------------------------------------------------- |
+| `options`                          | Optional options                                                                             |
+| `options.filename`                 | Stats filename (default to `loadable-stats.json`)                                            |
+| `options.outputAsset`              | Always write stats file to the `output.path` directory. Defaults to `true`                   |
+| `options.writeToDisk`              | Accepts `boolean` or `object`. Always write stats file to disk. Default to `false`.          |
+| `options.writeToDisk.filename`     | Write assets to disk at given `filename` location                                            |
+| `options.chunkLoadingGlobal`       | Overrides Webpack's `chunkLoadingGlobal` allowing multiple Webpack runtimes on the same page |
+| `options.loadableStatsFileOptions` | Overrides Webpack's `stats` [options][] to allow modified `loadable-stats.json` output       |
 
 ```js
 new LoadablePlugin({ filename: 'stats.json', writeToDisk: true })
 ```
 
 > Writing file to disk can be useful if you are using `razzle` or `webpack-dev-server`.
+
+> Overriding the `loadable-stats.json` via options can be useful for build orchestration tools like `Bazel` that expect reproducible/hermetic output
+
+[options]: https://webpack.js.org/configuration/stats/


### PR DESCRIPTION
This change allows the end user to pass options
to the stats object to override them for their
given use cases. It will default to the old behavior
if no opts are passed.

Closes https://github.com/gregberge/loadable-components/issues/897

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Close https://github.com/gregberge/loadable-components/issues/897 in a non breaking way by allowing users to override specific stats opts, but fallback on the defaults if no opts passed.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Open to suggestions in this department. 
