### PR TITLE
Adds support for server side suspense and streaming

### DIFF
--- a/examples/streaming-server-side-rendering/.eslintrc.json
+++ b/examples/streaming-server-side-rendering/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "browser": true
+  },
+  "rules": {
+    "import/no-unresolved": "off",
+    "import/no-extraneous-dependencies": "off"
+  }
+}

--- a/examples/streaming-server-side-rendering/.gitignore
+++ b/examples/streaming-server-side-rendering/.gitignore
@@ -1,0 +1,1 @@
+public/dist

--- a/examples/streaming-server-side-rendering/README.md
+++ b/examples/streaming-server-side-rendering/README.md
@@ -1,0 +1,42 @@
+# Get the streaming SSR example running
+
+Steps:
+
+1. Download repository
+
+```bash
+git clone https://github.com/gregberge/loadable-components.git
+```
+
+2. Install [https://yarnpkg.com/lang/en/docs/install](yarn) if haven't already
+3. Install libary dependencies and build library
+
+```bash
+yarn
+yarn build
+```
+
+4. Move into example directory
+
+```bash
+cd ./loadable-components/examples/streaming-server-side-rendering
+```
+
+5. Install project dependencies
+
+```bash
+yarn
+```
+
+5. Run locally or build and serve
+
+```bash
+yarn dev
+
+# Or
+
+yarn build
+yarn start
+```
+
+🍻

--- a/examples/streaming-server-side-rendering/babel.config.js
+++ b/examples/streaming-server-side-rendering/babel.config.js
@@ -1,0 +1,32 @@
+function isWebTarget(caller) {
+  return Boolean(caller && caller.target === 'web')
+}
+
+function isWebpack(caller) {
+  return Boolean(caller && caller.name === 'babel-loader')
+}
+
+module.exports = api => {
+  const web = api.caller(isWebTarget)
+  const webpack = api.caller(isWebpack)
+
+  return {
+    presets: [
+      '@babel/preset-react',
+      [
+        '@babel/preset-env',
+        {
+          useBuiltIns: web ? 'entry' : undefined,
+          corejs: web ? 'core-js@3' : false,
+          targets: !web ? { node: 'current' } : undefined,
+          modules: webpack ? false : 'commonjs',
+        },
+      ],
+    ],
+    plugins: ['@babel/plugin-syntax-dynamic-import', '@loadable/babel-plugin', 
+/*     ["transform-define", {
+      "process.env.NODE_ENV": process.env.NODE_ENV,
+    }] */
+  ],
+  }
+}

--- a/examples/streaming-server-side-rendering/nodemon.json
+++ b/examples/streaming-server-side-rendering/nodemon.json
@@ -1,0 +1,6 @@
+{
+  "ignore": ["client", "public"],
+  "execMap": {
+    "js": "babel-node"
+  }
+}

--- a/examples/streaming-server-side-rendering/package.json
+++ b/examples/streaming-server-side-rendering/package.json
@@ -1,0 +1,39 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "nodemon src/server/main.js",
+    "build": "rm -Rf ./public && NODE_ENV=production yarn build:webpack && yarn build:lib",
+    "build:webpack": "webpack",
+    "build:lib": "babel -d lib src",
+    "start": "NODE_ENV=production node lib/server/main.js",
+    "link:all": "yarn link @loadable/babel-plugin && yarn link @loadable/server && yarn link @loadable/component"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.4.4",
+    "@babel/core": "^7.6.2",
+    "@babel/node": "^7.0.0",
+    "@babel/preset-env": "^7.6.2",
+    "@babel/preset-react": "^7.0.0",
+    "@loadable/babel-plugin": "file:./../../packages/babel-plugin",
+    "@loadable/component": "file:./../../packages/component",
+    "@loadable/server": "file:./../../packages/server",
+    "@loadable/webpack-plugin": "file:./../../packages/webpack-plugin",
+    "babel-loader": "^8.0.6",
+    "babel-plugin-transform-define": "^2.1.0",
+    "css-loader": "^2.1.1",
+    "mini-css-extract-plugin": "^0.6.0",
+    "nodemon": "^1.19.0",
+    "webpack": "^4.31.0",
+    "webpack-cli": "^3.3.2",
+    "webpack-dev-middleware": "^3.6.2",
+    "webpack-node-externals": "^1.7.2"
+  },
+  "dependencies": {
+    "core-js": "^3.0.1",
+    "express": "^4.18.2",
+    "moment": "^2.24.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-error-boundary": "^3.1.4"
+  }
+}

--- a/examples/streaming-server-side-rendering/src/client/App.js
+++ b/examples/streaming-server-side-rendering/src/client/App.js
@@ -1,24 +1,22 @@
 import React from 'react'
-import { ErrorBoundary } from 'react-error-boundary';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { lazy } from '@loadable/component'
+import { reactLazy } from '@loadable/component'
 import Html from './Html'
 
-const A = lazy(() => import('./letters/A'))
-const B = lazy(() => import('./letters/B'))
-const C = lazy(() => import(/* webpackPreload: true */ './letters/C'))
-const D = lazy(() => import(/* webpackPrefetch: true */ './letters/D'))
-const E = lazy(() => import('./letters/E?param'), { ssr: false })
-const X = lazy(props => import(`./letters/${props.letter}`))
-const Sub = lazy(props => import(`./letters/${props.letter}/file`))
-const RootSub = lazy(props => import(`./${props.letter}/file`))
+const A = reactLazy(() => import('./letters/A'))
+const B = reactLazy(() => import('./letters/B'))
+const C = reactLazy(() => import(/* webpackPreload: true */ './letters/C'))
+const D = reactLazy(() => import(/* webpackPrefetch: true */ './letters/D'))
+const E = reactLazy(() => import('./letters/E?param'), { ssr: false })
+const X = reactLazy(props => import(`./letters/${props.letter}`))
+const Sub = reactLazy(props => import(`./letters/${props.letter}/file`))
+const RootSub = reactLazy(props => import(`./${props.letter}/file`))
 
 const App = () => {
   return (
     <Html title="Hello">
     <React.Suspense fallback="Loading">
-      <ErrorBoundary FallbackComponent={Error}>  
           <A />
           <br />
           <B />
@@ -32,7 +30,6 @@ const App = () => {
           <Sub letter="Z" />
           <br />
           <RootSub letter="Y" />
-        </ErrorBoundary>
       </React.Suspense>
     </Html>
   )

--- a/examples/streaming-server-side-rendering/src/client/App.js
+++ b/examples/streaming-server-side-rendering/src/client/App.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import { ErrorBoundary } from 'react-error-boundary';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { lazy } from '@loadable/component'
+import Html from './Html'
+
+const A = lazy(() => import('./letters/A'))
+const B = lazy(() => import('./letters/B'))
+const C = lazy(() => import(/* webpackPreload: true */ './letters/C'))
+const D = lazy(() => import(/* webpackPrefetch: true */ './letters/D'))
+const E = lazy(() => import('./letters/E?param'), { ssr: false })
+const X = lazy(props => import(`./letters/${props.letter}`))
+const Sub = lazy(props => import(`./letters/${props.letter}/file`))
+const RootSub = lazy(props => import(`./${props.letter}/file`))
+
+const App = () => {
+  return (
+    <Html title="Hello">
+    <React.Suspense fallback="Loading">
+      <ErrorBoundary FallbackComponent={Error}>  
+          <A />
+          <br />
+          <B />
+          <br />
+          <X letter="A" />
+          <br />
+          <X letter="F" />
+          <br />
+          <E />
+          <br />
+          <Sub letter="Z" />
+          <br />
+          <RootSub letter="Y" />
+        </ErrorBoundary>
+      </React.Suspense>
+    </Html>
+  )
+}
+
+function Error({ error }) {
+  return (
+    <div>
+      <h1>Application Error</h1>
+      <pre style={{ whiteSpace: 'pre-wrap' }}>{error.stack}</pre>
+    </div>
+  );
+}
+
+export default App

--- a/examples/streaming-server-side-rendering/src/client/Html.js
+++ b/examples/streaming-server-side-rendering/src/client/Html.js
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export default function Html({ children, title }) {
+    return (
+      <html lang="en">
+        <head>
+          <meta charSet="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <link rel="shortcut icon" href="favicon.ico" />
+          <title>{title}</title>
+        </head>
+        <body>
+          <noscript
+            dangerouslySetInnerHTML={{
+              __html: `<b>Enable JavaScript to run this app.</b>`
+            }}
+          />
+          {children}
+        </body>
+      </html>
+    );
+  }
+  

--- a/examples/streaming-server-side-rendering/src/client/Y/file.js
+++ b/examples/streaming-server-side-rendering/src/client/Y/file.js
@@ -1,0 +1,1 @@
+export default () => 'Y'

--- a/examples/streaming-server-side-rendering/src/client/letters/A.css
+++ b/examples/streaming-server-side-rendering/src/client/letters/A.css
@@ -1,0 +1,4 @@
+/* A CSS */
+body {
+    background: pink;
+}

--- a/examples/streaming-server-side-rendering/src/client/letters/A.js
+++ b/examples/streaming-server-side-rendering/src/client/letters/A.js
@@ -1,0 +1,6 @@
+// We simulate that "moment" is called in "A" and "B"
+
+const A = () => 'A'
+
+
+export default A

--- a/examples/streaming-server-side-rendering/src/client/letters/B.js
+++ b/examples/streaming-server-side-rendering/src/client/letters/B.js
@@ -1,0 +1,6 @@
+// We simulate that "moment" is called in "A" and "B"
+
+const B = () => 'B'
+
+
+export default B

--- a/examples/streaming-server-side-rendering/src/client/letters/C.js
+++ b/examples/streaming-server-side-rendering/src/client/letters/C.js
@@ -1,0 +1,1 @@
+export default () => 'C'

--- a/examples/streaming-server-side-rendering/src/client/letters/D.js
+++ b/examples/streaming-server-side-rendering/src/client/letters/D.js
@@ -1,0 +1,1 @@
+export default () => 'D'

--- a/examples/streaming-server-side-rendering/src/client/letters/E.js
+++ b/examples/streaming-server-side-rendering/src/client/letters/E.js
@@ -1,0 +1,1 @@
+export default () => 'E'

--- a/examples/streaming-server-side-rendering/src/client/letters/F.js
+++ b/examples/streaming-server-side-rendering/src/client/letters/F.js
@@ -1,0 +1,1 @@
+export default () => 'F'

--- a/examples/streaming-server-side-rendering/src/client/letters/G.js
+++ b/examples/streaming-server-side-rendering/src/client/letters/G.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const G = ({ prefix }) => <span className="my-cool-class">{prefix} - G</span>
+
+export default G

--- a/examples/streaming-server-side-rendering/src/client/letters/Z/file.js
+++ b/examples/streaming-server-side-rendering/src/client/letters/Z/file.js
@@ -1,0 +1,1 @@
+export default () => 'Z'

--- a/examples/streaming-server-side-rendering/src/client/main-node.js
+++ b/examples/streaming-server-side-rendering/src/client/main-node.js
@@ -1,0 +1,3 @@
+export { default } from './App'
+
+export const hello = 'hello'

--- a/examples/streaming-server-side-rendering/src/client/main-web.js
+++ b/examples/streaming-server-side-rendering/src/client/main-web.js
@@ -1,0 +1,7 @@
+import 'core-js'
+import React from 'react'
+import { hydrateRoot } from "react-dom/client";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import App from './App'
+
+hydrateRoot(document, <App />);

--- a/examples/streaming-server-side-rendering/src/client/main.css
+++ b/examples/streaming-server-side-rendering/src/client/main.css
@@ -1,0 +1,4 @@
+/* Main CSS */
+h1 {
+    color: cyan;
+}

--- a/examples/streaming-server-side-rendering/src/server/main.js
+++ b/examples/streaming-server-side-rendering/src/server/main.js
@@ -1,0 +1,128 @@
+import path from 'path'
+import express, { json } from 'express'
+import React from 'react'
+import { renderToPipeableStream } from 'react-dom/server';
+import { ChunkExtractor } from '@loadable/server'
+import { Writable } from 'stream';
+import fs from 'fs';
+
+const app = express()
+
+app.use(express.static(path.join(__dirname, '../../public')))
+
+if (process.env.NODE_ENV !== 'production') {
+  /* eslint-disable global-require, import/no-extraneous-dependencies */
+  const { default: webpackConfig } = require('../../webpack.config.babel')
+  const webpackDevMiddleware = require('webpack-dev-middleware')
+  const webpack = require('webpack')
+  /* eslint-enable global-require, import/no-extraneous-dependencies */
+
+  const compiler = webpack(webpackConfig)
+
+  app.use(
+    webpackDevMiddleware(compiler, {
+      logLevel: 'silent',
+      publicPath: '/dist/web',
+      writeToDisk(filePath) {
+        return /dist\/node\//.test(filePath) || /loadable-stats/.test(filePath)
+      },
+    }),
+  )
+}
+
+const nodeStats = path.resolve(
+  __dirname,
+  '../../public/dist/node/loadable-stats.json',
+)
+
+const webStats = path.resolve(
+  __dirname,
+  '../../public/dist/web/loadable-stats.json',
+)
+
+app.get('*', (req, res) => {
+  let didError = false;
+  let shellReady = false;
+  let firstWrite = true;
+
+  let statsNode = JSON.parse(fs.readFileSync(nodeStats))
+  let statsWeb = JSON.parse(fs.readFileSync(webStats))
+
+
+  const nodeExtractor = new ChunkExtractor({ stats: statsNode })
+  const { default: App } = nodeExtractor.requireEntrypoint()
+
+  const webExtractor = new ChunkExtractor({ stats: statsWeb })
+
+  const writeable = new Writable({
+    write(chunk, encoding, callback) {
+      // This should pick up any new link tags that hasn't been previously
+      // written to this stream. Should not write before html if nothing suspended.
+      if (shellReady && !firstWrite) {
+        const scriptTags = webExtractor.getScriptTagsSince()
+        const linkTags = webExtractor.getLinkTagsSince()
+        if (scriptTags) {
+          res.write(scriptTags, encoding)
+        }
+        if (linkTags) {
+          res.write(linkTags, encoding)
+        }
+        // Finally write whatever React tried to write.
+      }
+      firstWrite = false
+      res.write(chunk, encoding, callback)
+    },
+    final(callback) {
+      res.end()
+      callback()
+    },
+    flush() {
+      if (typeof res.flush === 'function') {
+        res.flush();
+      }
+    },
+    destroy(err) {
+      res.destroy(err ?? undefined)
+    }
+  })
+
+  const stream = renderToPipeableStream(webExtractor.collectChunks(<App />),
+    {
+      onShellReady() {
+        // The content above all Suspense boundaries is ready.
+        // If something errored before we started streaming, we set the error code appropriately.
+        res.statusCode = didError ? 500 : 200;
+        res.setHeader('Content-type', 'text/html');
+        stream.pipe(writeable);
+        shellReady = true;
+
+      },
+      onShellError(error) {
+        // Something errored before we could complete the shell so we emit an alternative shell.
+        res.statusCode = 500;
+        res.send(
+          '<!doctype html><p>Loading...</p><script src="clientrender.js"></script>'
+        );
+      },
+      onAllReady() {
+        // If you don't want streaming, use this instead of onShellReady.
+        // This will fire after the entire page content is ready.
+        // You can use this for crawlers or static generation.
+        // If nothing suspends, make sure scripts are written
+        writeable.write('')
+        // res.statusCode = didError ? 500 : 200;
+        // res.setHeader('Content-type', 'text/html');
+        // stream.pipe(res);
+      },
+      onError(err) {
+        didError = true;
+        console.error(err);
+      },
+    }
+  );
+
+
+});
+
+// eslint-disable-next-line no-console
+app.listen(9000, () => console.log('Server started http://localhost:9000'))

--- a/examples/streaming-server-side-rendering/src/server/main.js
+++ b/examples/streaming-server-side-rendering/src/server/main.js
@@ -59,8 +59,8 @@ app.get('*', (req, res) => {
       // This should pick up any new link tags that hasn't been previously
       // written to this stream. Should not write before html if nothing suspended.
       if (shellReady && !firstWrite) {
-        const scriptTags = webExtractor.getScriptTagsSince()
-        const linkTags = webExtractor.getLinkTagsSince()
+        const scriptTags = webExtractor.flushScriptTags()
+        const linkTags = webExtractor.flushLinkTags()
         if (scriptTags) {
           res.write(scriptTags, encoding)
         }

--- a/examples/streaming-server-side-rendering/webpack.config.babel.js
+++ b/examples/streaming-server-side-rendering/webpack.config.babel.js
@@ -1,0 +1,74 @@
+import path from 'path'
+import webpack from 'webpack'
+import nodeExternals from 'webpack-node-externals'
+import LoadablePlugin from '@loadable/webpack-plugin'
+import MiniCssExtractPlugin from 'mini-css-extract-plugin'
+
+const DIST_PATH = path.resolve(__dirname, 'public/dist')
+const production = process.env.NODE_ENV === 'production'
+const development =
+  !process.env.NODE_ENV || process.env.NODE_ENV === 'development'
+
+const getConfig = target => ({
+  name: target,
+  mode: development ? 'development' : 'production',
+  target,
+  entry: `./src/client/main-${target}.js`,
+  module: {
+    rules: [
+      {
+        test: /\.js?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            caller: { target },
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+          },
+          'css-loader',
+        ],
+      },
+    ],
+  },
+  optimization: {
+    moduleIds: 'named',
+    chunkIds: 'named',
+    minimize: false
+  },
+  resolve: {
+    modules: [path.resolve(__dirname, 'node_modules'), 'node_modules'],
+  },
+  externals:
+    target === 'node' ? [
+      '@loadable/component',
+      nodeExternals()
+    ] : undefined,
+  output: {
+    path: path.join(DIST_PATH, target),
+    // filename: production ? '[name]-bundle-[chunkhash:8].js' : '[name].js',
+    filename: production ? '[name].js' : '[name].js',
+    publicPath: `/dist/${target}/`,
+    libraryTarget: target === 'node' ? 'commonjs2' : undefined,
+  },
+  plugins: [
+    new LoadablePlugin(),
+    new MiniCssExtractPlugin(),
+    new webpack.DefinePlugin({ "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV)}),
+    new webpack.NormalModuleReplacementPlugin(
+      /^react$/,
+      'react/cjs/react.development.js',
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /^react-dom$/,
+      'react-dom/cjs/react-dom.development.js',
+    ),],
+})
+
+export default [getConfig('web'), getConfig('node')]

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -41,11 +41,17 @@ const loadablePlugin = api => {
     }
 
     // `loadable.lib()`
-    return (
+    if (
       path.get('callee').isMemberExpression() &&
       path.get('callee.object').isIdentifier({ name: 'loadable' }) &&
       path.get('callee.property').isIdentifier({ name: 'lib' })
-    )
+    ) {
+      return true
+    }
+
+    // `lazy()`
+    return (path.get('callee').isIdentifier({ name: 'lazy' }))
+    
   }
 
   function hasLoadableComment(path) {

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -49,8 +49,8 @@ const loadablePlugin = api => {
       return true
     }
 
-    // `lazy()`
-    return (path.get('callee').isIdentifier({ name: 'lazy' }))
+    // `lazy(), reactLazy()`
+    return (path.get('callee').isIdentifier({ name: 'lazy' }) || path.get('callee').isIdentifier({ name: 'reactLazy' }))
     
   }
 

--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/loadable.cjs.js": {
-    "bundled": 16760,
-    "minified": 7400,
-    "gzipped": 2617
+    "bundled": 16952,
+    "minified": 7470,
+    "gzipped": 2631
   },
   "dist/loadable.esm.js": {
-    "bundled": 16381,
-    "minified": 7096,
-    "gzipped": 2550,
+    "bundled": 16573,
+    "minified": 7166,
+    "gzipped": 2564,
     "treeshaked": {
       "rollup": {
         "code": 276,
         "import_statements": 276
       },
       "webpack": {
-        "code": 5969
+        "code": 6034
       }
     }
   }

--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/loadable.cjs.js": {
-    "bundled": 16952,
-    "minified": 7470,
-    "gzipped": 2631
+    "bundled": 17958,
+    "minified": 7858,
+    "gzipped": 2724
   },
   "dist/loadable.esm.js": {
-    "bundled": 16573,
-    "minified": 7166,
-    "gzipped": 2564,
+    "bundled": 17572,
+    "minified": 7549,
+    "gzipped": 2652,
     "treeshaked": {
       "rollup": {
         "code": 276,
         "import_statements": 276
       },
       "webpack": {
-        "code": 6034
+        "code": 6298
       }
     }
   }

--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/loadable.cjs.js": {
-    "bundled": 17958,
-    "minified": 7858,
-    "gzipped": 2724
+    "bundled": 18151,
+    "minified": 8002,
+    "gzipped": 2788
   },
   "dist/loadable.esm.js": {
-    "bundled": 17572,
-    "minified": 7549,
-    "gzipped": 2652,
+    "bundled": 17765,
+    "minified": 7693,
+    "gzipped": 2718,
     "treeshaked": {
       "rollup": {
         "code": 276,
         "import_statements": 276
       },
       "webpack": {
-        "code": 6298
+        "code": 6434
       }
     }
   }

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -119,6 +119,7 @@ function createLoadable({
       return promise
     }
     const lazyCachedLoad = props => {
+      if (props.__chunkExtractor && options.ssr === false) return null
       const cacheKey = getCacheKey(props)
       let lazyOrComponent = cache[cacheKey]
 
@@ -155,6 +156,11 @@ function createLoadable({
         invariant(
           !props.__chunkExtractor || ctor.requireSync,
           'SSR requires `@loadable/babel-plugin`, please install it',
+        )
+
+        invariant(
+          !options.reactLazy || !props.fallback,
+          'reactLazy cannot be used with fallback, wrap in a Suspense',
         )
 
         // Server-side
@@ -330,7 +336,7 @@ function createLoadable({
         if (options.reactLazy) {
           return render({
             fallback,
-            result: lazyCachedLoad(props),
+            result: lazyCachedLoad(props) ,
             options,
             props: { ...props, ref: forwardedRef },
           })

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -151,16 +151,22 @@ function createLoadable({
           if (options.ssr === false) {
             return
           }
+          
+          if (!options.suspense) {
+            // We run load function, we assume that it won't fail and that it
+            // triggers a synchronous loading of the module
+            ctor.requireAsync(props).catch(() => null)
 
-          // We run load function, we assume that it won't fail and that it
-          // triggers a synchronous loading of the module
-          ctor.requireAsync(props).catch(() => null)
+            // So we can require now the module synchronously
+            this.loadSync()
 
-          // So we can require now the module synchronously
-          this.loadSync()
+            props.__chunkExtractor.addChunk(ctor.chunkName(props))
+
+            return
+          }
 
           props.__chunkExtractor.addChunk(ctor.chunkName(props))
-          return
+          
         }
 
         // Client-side with `isReady` method present (SSR probably)

--- a/packages/component/src/index.js
+++ b/packages/component/src/index.js
@@ -6,11 +6,12 @@ import * as libraryExports from './library'
 const { loadable } = loadableExports
 loadable.lib = libraryExports.loadable
 
-const { lazy } = loadableExports
+const { lazy, reactLazy } = loadableExports
 lazy.lib = libraryExports.lazy
+reactLazy.lib = libraryExports.reactLazy
 
 export default loadable
-export { lazy }
+export { lazy, reactLazy }
 
 export { default as loadableReady } from './loadableReady'
 export const __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = sharedInternals

--- a/packages/component/src/library.js
+++ b/packages/component/src/library.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define, react/no-multi-comp */
 import createLoadable from './createLoadable'
 
-export const { loadable, lazy } = createLoadable({
+export const { loadable, lazy, reactLazy } = createLoadable({
   onLoad(result, props) {
     if (result && props.forwardedRef) {
       if (typeof props.forwardedRef === 'function') {

--- a/packages/component/src/loadable.js
+++ b/packages/component/src/loadable.js
@@ -3,7 +3,7 @@ import React from 'react'
 import createLoadable from './createLoadable'
 import { defaultResolveComponent } from './resolvers'
 
-export const { loadable, lazy } = createLoadable({
+export const { loadable, lazy, reactLazy } = createLoadable({
   defaultResolveComponent,
   render({ result: Component, props }) {
     return <Component {...props} />


### PR DESCRIPTION
## Summary

React 18 now supports  server side suspense and streaming.

This pull updates the babel plugin to transform `lazy`, makes the component suspend server-side and adds two methods to `ChunkExtractor` to incrementally write tags for streaming rendering.

## Test plan

Run the example app at

https://github.com/fivethreeo/loadable-components/tree/feature/server-side-suspense/examples/streaming-server-side-rendering)