### PR TITLE
Allow additional identifiers to be passed in to the babel plugin

### DIFF
--- a/packages/babel-plugin/src/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin/src/__snapshots__/index.test.js.snap
@@ -232,6 +232,64 @@ exports[`plugin Magic comment should transpile shortand properties 1`] = `
 };"
 `;
 
+exports[`plugin additionalSpecifiers Should match on custom specifiers 1`] = `
+"LoadableHOC({
+  resolved: {},
+
+  chunkName() {
+    return \`ModA\`.replace(/[^a-zA-Z0-9_!§$()=\\\\-^°]+/g, \\"-\\");
+  },
+
+  isReady(props) {
+    const key = this.resolve(props);
+
+    if (this.resolved[key] !== true) {
+      return false;
+    }
+
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[key];
+    }
+
+    return false;
+  },
+
+  importAsync: () => import(
+  /* webpackChunkName: \\"ModA\\" */
+  \`./ModA\`),
+
+  requireAsync(props) {
+    const key = this.resolve(props);
+    this.resolved[key] = false;
+    return this.importAsync(props).then(resolved => {
+      this.resolved[key] = true;
+      return resolved;
+    });
+  },
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\`./ModA\`);
+    }
+
+    return eval('require.resolve')(\`./ModA\`);
+  }
+
+});"
+`;
+
+exports[`plugin additionalSpecifiers Should not match on undeclared specifiers 1`] = `"LoadableHOC(() => import(\`./ModA\`));"`;
+
 exports[`plugin aggressive import should work with destructuration 1`] = `
 "import loadable from '@loadable/component';
 loadable({

--- a/packages/babel-plugin/src/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin/src/__snapshots__/index.test.js.snap
@@ -232,64 +232,6 @@ exports[`plugin Magic comment should transpile shortand properties 1`] = `
 };"
 `;
 
-exports[`plugin additionalSpecifiers Should match on custom specifiers 1`] = `
-"LoadableHOC({
-  resolved: {},
-
-  chunkName() {
-    return \`ModA\`.replace(/[^a-zA-Z0-9_!§$()=\\\\-^°]+/g, \\"-\\");
-  },
-
-  isReady(props) {
-    const key = this.resolve(props);
-
-    if (this.resolved[key] !== true) {
-      return false;
-    }
-
-    if (typeof __webpack_modules__ !== 'undefined') {
-      return !!__webpack_modules__[key];
-    }
-
-    return false;
-  },
-
-  importAsync: () => import(
-  /* webpackChunkName: \\"ModA\\" */
-  \`./ModA\`),
-
-  requireAsync(props) {
-    const key = this.resolve(props);
-    this.resolved[key] = false;
-    return this.importAsync(props).then(resolved => {
-      this.resolved[key] = true;
-      return resolved;
-    });
-  },
-
-  requireSync(props) {
-    const id = this.resolve(props);
-
-    if (typeof __webpack_require__ !== 'undefined') {
-      return __webpack_require__(id);
-    }
-
-    return eval('module.require')(id);
-  },
-
-  resolve() {
-    if (require.resolveWeak) {
-      return require.resolveWeak(\`./ModA\`);
-    }
-
-    return eval('require.resolve')(\`./ModA\`);
-  }
-
-});"
-`;
-
-exports[`plugin additionalSpecifiers Should not match on undeclared specifiers 1`] = `"LoadableHOC(() => import(\`./ModA\`));"`;
-
 exports[`plugin aggressive import should work with destructuration 1`] = `
 "import loadable from '@loadable/component';
 loadable({
@@ -644,6 +586,244 @@ loadable({
 });"
 `;
 
+exports[`plugin custom signatures named signature should not match default import 1`] = `
+"import myLoadable from 'myLoadablePackage';
+myLoadable(() => import(\`./ModA\`));"
+`;
+
+exports[`plugin custom signatures should match custom default signature 1`] = `
+"import myLoadable from 'myLoadablePackage';
+myLoadable({
+  resolved: {},
+
+  chunkName() {
+    return \`ModA\`.replace(/[^a-zA-Z0-9_!§$()=\\\\-^°]+/g, \\"-\\");
+  },
+
+  isReady(props) {
+    const key = this.resolve(props);
+
+    if (this.resolved[key] !== true) {
+      return false;
+    }
+
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[key];
+    }
+
+    return false;
+  },
+
+  importAsync: () => import(
+  /* webpackChunkName: \\"ModA\\" */
+  \`./ModA\`),
+
+  requireAsync(props) {
+    const key = this.resolve(props);
+    this.resolved[key] = false;
+    return this.importAsync(props).then(resolved => {
+      this.resolved[key] = true;
+      return resolved;
+    });
+  },
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\`./ModA\`);
+    }
+
+    return eval('require.resolve')(\`./ModA\`);
+  }
+
+});"
+`;
+
+exports[`plugin custom signatures should match custom named signature 1`] = `
+"import { myLoadable } from 'myLoadablePackage';
+myLoadable({
+  resolved: {},
+
+  chunkName() {
+    return \`ModA\`.replace(/[^a-zA-Z0-9_!§$()=\\\\-^°]+/g, \\"-\\");
+  },
+
+  isReady(props) {
+    const key = this.resolve(props);
+
+    if (this.resolved[key] !== true) {
+      return false;
+    }
+
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[key];
+    }
+
+    return false;
+  },
+
+  importAsync: () => import(
+  /* webpackChunkName: \\"ModA\\" */
+  \`./ModA\`),
+
+  requireAsync(props) {
+    const key = this.resolve(props);
+    this.resolved[key] = false;
+    return this.importAsync(props).then(resolved => {
+      this.resolved[key] = true;
+      return resolved;
+    });
+  },
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\`./ModA\`);
+    }
+
+    return eval('require.resolve')(\`./ModA\`);
+  }
+
+});"
+`;
+
+exports[`plugin custom signatures should match renamed default import 1`] = `
+"import renamedLoadable from '@loadable/component';
+renamedLoadable({
+  resolved: {},
+
+  chunkName() {
+    return \`ModA\`.replace(/[^a-zA-Z0-9_!§$()=\\\\-^°]+/g, \\"-\\");
+  },
+
+  isReady(props) {
+    const key = this.resolve(props);
+
+    if (this.resolved[key] !== true) {
+      return false;
+    }
+
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[key];
+    }
+
+    return false;
+  },
+
+  importAsync: () => import(
+  /* webpackChunkName: \\"ModA\\" */
+  \`./ModA\`),
+
+  requireAsync(props) {
+    const key = this.resolve(props);
+    this.resolved[key] = false;
+    return this.importAsync(props).then(resolved => {
+      this.resolved[key] = true;
+      return resolved;
+    });
+  },
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\`./ModA\`);
+    }
+
+    return eval('require.resolve')(\`./ModA\`);
+  }
+
+});"
+`;
+
+exports[`plugin custom signatures should match simple default import 1`] = `
+"import loadable from '@loadable/component';
+loadable({
+  resolved: {},
+
+  chunkName() {
+    return \`ModA\`.replace(/[^a-zA-Z0-9_!§$()=\\\\-^°]+/g, \\"-\\");
+  },
+
+  isReady(props) {
+    const key = this.resolve(props);
+
+    if (this.resolved[key] !== true) {
+      return false;
+    }
+
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[key];
+    }
+
+    return false;
+  },
+
+  importAsync: () => import(
+  /* webpackChunkName: \\"ModA\\" */
+  \`./ModA\`),
+
+  requireAsync(props) {
+    const key = this.resolve(props);
+    this.resolved[key] = false;
+    return this.importAsync(props).then(resolved => {
+      this.resolved[key] = true;
+      return resolved;
+    });
+  },
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\`./ModA\`);
+    }
+
+    return eval('require.resolve')(\`./ModA\`);
+  }
+
+});"
+`;
+
+exports[`plugin custom signatures should not match on undeclared specifiers 1`] = `
+"import myLoadable from 'myLoadablePackage';
+myLoadable(() => import(\`./ModA\`));"
+`;
+
 exports[`plugin loadable.lib should be transpiled too 1`] = `
 "import loadable from '@loadable/component';
 loadable.lib({
@@ -756,11 +936,6 @@ loadable({
   }
 
 });"
-`;
-
-exports[`plugin simple import should not work with renamed specifier by default 1`] = `
-"import renamedLoadable from '@loadable/component';
-renamedLoadable(() => import(\`./ModA\`));"
 `;
 
 exports[`plugin simple import should transform path into "chunk-friendly" name 1`] = `
@@ -994,6 +1169,63 @@ lazy({
 exports[`plugin simple import should work with renamed lazy specifier 1`] = `
 "import { lazy as renamedLazy } from '@loadable/component';
 renamedLazy({
+  resolved: {},
+
+  chunkName() {
+    return \`ModA\`.replace(/[^a-zA-Z0-9_!§$()=\\\\-^°]+/g, \\"-\\");
+  },
+
+  isReady(props) {
+    const key = this.resolve(props);
+
+    if (this.resolved[key] !== true) {
+      return false;
+    }
+
+    if (typeof __webpack_modules__ !== 'undefined') {
+      return !!__webpack_modules__[key];
+    }
+
+    return false;
+  },
+
+  importAsync: () => import(
+  /* webpackChunkName: \\"ModA\\" */
+  \`./ModA\`),
+
+  requireAsync(props) {
+    const key = this.resolve(props);
+    this.resolved[key] = false;
+    return this.importAsync(props).then(resolved => {
+      this.resolved[key] = true;
+      return resolved;
+    });
+  },
+
+  requireSync(props) {
+    const id = this.resolve(props);
+
+    if (typeof __webpack_require__ !== 'undefined') {
+      return __webpack_require__(id);
+    }
+
+    return eval('module.require')(id);
+  },
+
+  resolve() {
+    if (require.resolveWeak) {
+      return require.resolveWeak(\`./ModA\`);
+    }
+
+    return eval('require.resolve')(\`./ModA\`);
+  }
+
+});"
+`;
+
+exports[`plugin simple import should work with renamed specifier by default 1`] = `
+"import renamedLoadable from '@loadable/component';
+renamedLoadable({
   resolved: {},
 
   chunkName() {

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -20,7 +20,10 @@ const properties = [
 
 const LOADABLE_COMMENT = '#__LOADABLE__'
 
-const loadablePlugin = declare((api, { defaultImportSpecifier = 'loadable' }) => {
+const loadablePlugin = declare((api, { 
+  defaultImportSpecifier = 'loadable',
+  additionalSpecifiers = []
+ }) => {
   const { types: t } = api
 
   function collectImportCallPaths(startPath) {
@@ -43,6 +46,11 @@ const loadablePlugin = declare((api, { defaultImportSpecifier = 'loadable' }) =>
 
     // `lazy()`
     if (lazyImportSpecifier && path.get('callee').isIdentifier({ name: lazyImportSpecifier })) {
+      return true
+    }
+
+    // Additional, custom specifiers.  e.g. LoadableHOC()
+    if (additionalSpecifiers.find(specifier => path.get('callee').isIdentifier({ name: specifier }))) {
       return true
     }
 

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -21,9 +21,11 @@ const properties = [
 const LOADABLE_COMMENT = '#__LOADABLE__'
 
 const loadablePlugin = declare((api, { 
-  defaultImportSpecifier = 'loadable',
-  additionalSpecifiers = []
+  signatures = []
  }) => {
+  if (!signatures.find(sig => sig.from == '@loadable/component')) {
+    signatures.push({name: 'default', from: '@loadable/component'})
+  }
   const { types: t } = api
 
   function collectImportCallPaths(startPath) {
@@ -38,9 +40,9 @@ const loadablePlugin = declare((api, {
 
   const propertyFactories = properties.map(init => init(api))
 
-  function isValidIdentifier(path, loadableImportSpecifier, lazyImportSpecifier) {
-    // `loadable()`
-    if (loadableImportSpecifier && path.get('callee').isIdentifier({ name: loadableImportSpecifier })) {
+  function isValidIdentifier(path, loadableImportSpecifiers, lazyImportSpecifier) {
+    // loadable signatures
+    if (loadableImportSpecifiers.find(specifier => path.get('callee').isIdentifier({ name: specifier }))) {
       return true
     }
 
@@ -49,16 +51,10 @@ const loadablePlugin = declare((api, {
       return true
     }
 
-    // Additional, custom specifiers.  e.g. LoadableHOC()
-    if (additionalSpecifiers.find(specifier => path.get('callee').isIdentifier({ name: specifier }))) {
-      return true
-    }
-
     // `loadable.lib()`
     return (
-      loadableImportSpecifier &&
       path.get('callee').isMemberExpression() &&
-      path.get('callee.object').isIdentifier({ name: loadableImportSpecifier }) &&
+      loadableImportSpecifiers.find(specifier => path.get('callee.object').isIdentifier({ name: specifier })) &&
       path.get('callee.property').isIdentifier({ name: 'lib' })
     )
   }
@@ -127,28 +123,30 @@ const loadablePlugin = declare((api, {
     visitor: {
       Program: {
         enter(programPath) {
-          let loadableImportSpecifier = defaultImportSpecifier
           let lazyImportSpecifier = false
+          const loadableSpecifiers = []
 
           programPath.traverse({
             ImportDefaultSpecifier(path) {
-              if (!loadableImportSpecifier) {
-                const { parent } = path
-                const { local } = path.node
-                loadableImportSpecifier = parent.source.value == '@loadable/component' &&
-                  local && local.name
+              const { parent } = path
+              const { local } = path.node
+              if (local && signatures.find(signature => signature.name === 'default' && parent.source.value === signature.from)) {
+                loadableSpecifiers.push(local.name)
               }
             },
             ImportSpecifier(path) {
+              const { parent } = path
+              const { imported, local } = path.node
               if (!lazyImportSpecifier) {
-                const { parent } = path
-                const { imported, local } = path.node
                 lazyImportSpecifier = parent.source.value == '@loadable/component' &&
                   imported && imported.name == 'lazy' && local && local.name
               }
+              if (local && imported && signatures.find(signature => imported.name === signature.name && parent.source.value === signature.from)) {
+                loadableSpecifiers.push(local.name)
+              }
             },
             CallExpression(path) {
-              if (!isValidIdentifier(path, loadableImportSpecifier, lazyImportSpecifier)) return
+              if (!isValidIdentifier(path, loadableSpecifiers, lazyImportSpecifier)) return
               transformImport(path)
             },
             'ArrowFunctionExpression|FunctionExpression|ObjectMethod': path => {

--- a/packages/babel-plugin/src/index.test.js
+++ b/packages/babel-plugin/src/index.test.js
@@ -40,7 +40,7 @@ describe('plugin', () => {
         lazy(() => import(\`./ModA\`));"
       `)
     })
-    it('should not work with renamed specifier by default', () => {
+    it('should work with renamed specifier by default', () => {
       const result = testPlugin(`
         import renamedLoadable from '@loadable/component'
         renamedLoadable(() => import(\`./ModA\`))
@@ -202,17 +202,46 @@ describe('plugin', () => {
     })
   })
 
-  describe('additionalSpecifiers', () => {
-    it('Should match on custom specifiers', () => {
+  describe('custom signatures', () => {
+    it('should match simple default import', () => {
       const result = testPlugin(`
-        LoadableHOC(() => import(\`./ModA\`))
-      `, { additionalSpecifiers: ['LoadableHOC']})
-
+        import loadable from '@loadable/component'
+        loadable(() => import(\`./ModA\`))
+      `, { signatures: [{ name: 'default', from: '@loadable/component' }]})
       expect(result).toMatchSnapshot()
     })
-    it('Should not match on undeclared specifiers', () => {
+    it('should match renamed default import', () => {
       const result = testPlugin(`
-        LoadableHOC(() => import(\`./ModA\`))
+        import renamedLoadable from '@loadable/component'
+        renamedLoadable(() => import(\`./ModA\`))
+      `, { signatures: [{ name: 'default', from: '@loadable/component' }]})
+      expect(result).toMatchSnapshot()
+    })
+    it('should match custom default signature', () => {
+      const result = testPlugin(`
+        import myLoadable from 'myLoadablePackage'
+        myLoadable(() => import(\`./ModA\`))
+      `, { signatures: [{ name: 'default', from: 'myLoadablePackage' }]})
+      expect(result).toMatchSnapshot()
+    })
+    it('should match custom named signature', () => {
+      const result = testPlugin(`
+        import { myLoadable } from 'myLoadablePackage'
+        myLoadable(() => import(\`./ModA\`))
+      `, { signatures: [{ name: 'myLoadable', from: 'myLoadablePackage' }]})
+      expect(result).toMatchSnapshot()
+    })
+    it('named signature should not match default import', () => {
+      const result = testPlugin(`
+        import myLoadable from 'myLoadablePackage'
+        myLoadable(() => import(\`./ModA\`))
+      `, { signatures: [{ name: 'myLoadable', from: 'myLoadablePackage' }]})
+      expect(result).toMatchSnapshot()
+    })
+    it('should not match on undeclared specifiers', () => {
+      const result = testPlugin(`
+        import myLoadable from 'myLoadablePackage'
+        myLoadable(() => import(\`./ModA\`))
       `)
       expect(result).toMatchSnapshot()
     })

--- a/packages/babel-plugin/src/index.test.js
+++ b/packages/babel-plugin/src/index.test.js
@@ -2,9 +2,9 @@
 import { transform } from '@babel/core'
 import plugin from '.'
 
-const testPlugin = code => {
+const testPlugin = (code, options) => {
   const result = transform(code, {
-    plugins: [plugin],
+    plugins: [[plugin, options]],
     configFile: false,
   })
 
@@ -198,6 +198,22 @@ describe('plugin', () => {
         loadable.lib(() => import('moment'))
       `)
 
+      expect(result).toMatchSnapshot()
+    })
+  })
+
+  describe('additionalSpecifiers', () => {
+    it('Should match on custom specifiers', () => {
+      const result = testPlugin(`
+        LoadableHOC(() => import(\`./ModA\`))
+      `, { additionalSpecifiers: ['LoadableHOC']})
+
+      expect(result).toMatchSnapshot()
+    })
+    it('Should not match on undeclared specifiers', () => {
+      const result = testPlugin(`
+        LoadableHOC(() => import(\`./ModA\`))
+      `)
       expect(result).toMatchSnapshot()
     })
   })


### PR DESCRIPTION
## Summary

I would like to wrap `loadable` in my own higher order component functions.  Loadable by default only injects a webpack chunk name  for `loadable` and `lazy`, but can readily accept additional identifiers.

This PR allows us to rewrite

```
// Loadable
const LoadableHelpPage = loadable(() => import('./HelpPage'), {
  resolveComponent: components => components.HelpPage,
})
// Our custom HOC
const HelpPage = PageHOC(LoadableHelpPage, {...additional page props })
```
to
```
const HelpPage = LoadablePageHOC(() => import('./HelpPage'), 'HelpPage', { ...additional page props })
```

We actually have a separate HOC for modals, so we would not be able to simply rename LoadablePageHOC to loadable for the sake of the existing babel plugin.  With the changes, we can specify `additionalIdentifiers: [ 'LoadablePageHOC', 'LoadableModalHOC']` to transform both.

## Test plan

New tests have been added that showcase the custom identifier being transformed or not, depending on babel options.
