### PR TITLE
fix: add "exports" field to package.json and rename ESM bundle to .mjs to fix ESM imports on node.js

### DIFF
--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -4,7 +4,7 @@
     "minified": 7394,
     "gzipped": 2621
   },
-  "dist/loadable.esm.js": {
+  "dist/loadable.esm.mjs": {
     "bundled": 16434,
     "minified": 7090,
     "gzipped": 2552,

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -2,8 +2,15 @@
   "name": "@loadable/component",
   "description": "React code splitting made easy.",
   "version": "5.15.3",
-  "main": "dist/loadable.cjs.js",
-  "module": "dist/loadable.esm.js",
+  "main": "./dist/loadable.cjs.js",
+  "module": "./dist/loadable.esm.mjs",
+  "exports": {
+    ".": {
+      "require": "./dist/loadable.cjs.js",
+      "import": "./dist/loadable.esm.mjs",
+      "default": "./dist/loadable.cjs.js"
+    }
+  },
   "repository": "git@github.com:gregberge/loadable-components.git",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "publishConfig": {

--- a/packages/server/__fixtures__/stats.json
+++ b/packages/server/__fixtures__/stats.json
@@ -1,7 +1,7 @@
 {
   "errors": [],
   "warnings": [],
-  "hash": "84e08a1809b7b09283e2",
+  "hash": "6cacb38ddc45b9bbd140",
   "publicPath": "/dist/node/",
   "outputPath": "../../examples/server-side-rendering/public/dist/node",
   "assetsByChunkName": {


### PR DESCRIPTION
## Summary

### Description of issue

Vite 5.0.0+ now removes the `exoports.default` to `default` ESM export proxy it used previously.<br />
Unfortunately this breaks the following import `import loadable from '@loadable/component'` because the dependency is treated as CommonJS export and `vite` doesn't proxy the `default` export for CommonJS files anymore.<br />
There is still a flag to enable the old behaviour, but that flag is due to be removed in Vite 6.0.0+, which would break the default import with this extension<br />

### What this fix does

This is a quick and dirty fix duplicates the default export as a named export called `loadable`, so we can also import `import { loadable } from '@loadable/component'` which works with Vite 5.0.0+.<br />
More info about the deprecation: https://vitejs.dev/guide/migration#ssr-externalized-modules-value-now-matches-production


### Alternative (more laborious, but future proof) solution that can be implemented instead of this

I'm currently open to implement this instead since it's way better to have proper exports in terms of future `node.js` & `vite` ESM compatibility.<br />
Here is what needs to be done to future-proof the package:

1. '@loadable/component' ESM build should have the `.mjs` extension.

    - **NOTE 1: all major bundlers already support the .mjs extension without any issue.**
    - **NOTE 2: node.js also supports this natively when the `exports` map is in the `package.json` file (see issue 2 for more info)**.
    
2. '@loadable/component' should have `exports` map is set to properly point to `loadable.esm.mjs` for ESM and `loadable.cjs.js` for CommonJS respectively.<br />
    
    Example `exports` map in package.json:
    ```json5
    {
        // ...
        "main": "dist/loadable.cjs.js",
        "module": "dist/loadable.esm.mjs",
        "exports": {
          ".": {
            "require": "./dist/loadable.cjs.js",
            "import": "./dist/loadable.esm.mjs",
            "default": "./dist/loadable.cjs.js"
          }
        },
        // ..
    }
    ```

## Test plan

I made a build with the current code and tested that the `import { loadable } from '@loadable/component'` actually works.
Feel free to point me out in case some tests or documentation needs to be updated also.
