### PR TITLE
fix: correct react-is for mjs export

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-use-before-define, react/no-multi-comp, no-underscore-dangle */
 import React from 'react'
-import * as ReactIs from 'react-is'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import { invariant } from './util'
 import Context from './Context'
@@ -77,11 +76,12 @@ function createLoadable({
         ? options.resolveComponent(module, props)
         : defaultResolveComponent(module)
 
-      if (options.resolveComponent && !ReactIs.isValidElementType(Component)) {
-        throw new Error(
-          `resolveComponent returned something that is not a React component!`,
-        )
-      }
+      // FIXME: suppressed due to https://github.com/gregberge/loadable-components/issues/990
+      // if (options.resolveComponent && !ReactIs.isValidElementType(Component)) {
+      //   throw new Error(
+      //     `resolveComponent returned something that is not a React component!`,
+      //   )
+      // }
       hoistNonReactStatics(Loadable, Component, {
         preload: true,
       })

--- a/packages/component/src/loadable.test.js
+++ b/packages/component/src/loadable.test.js
@@ -69,8 +69,7 @@ describe('#loadable', () => {
   })
 
   afterEach(() => {
-    // eslint-disable-next-line no-console
-    console.error.mockRestore()
+    jest.restoreAllMocks();
   })
 
   it('renders nothing without a fallback', () => {


### PR DESCRIPTION
I've failed to understand root cause behind #990 and a _proper way_ to resolve the problem.
As "let's do something" correction I am removing the offending piece of code (typescript should handle that) and that should give more time to find the real fix.
