### PR TITLE
Bring back extensions in server package

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
     "react/sort-comp": "off",
     "react/jsx-props-no-spreading": "off",
     "react/state-in-constructor": "off",
+    "import/extensions": "off",
     "import/prefer-default-export": "off"
   }
 }

--- a/packages/server/src/ChunkExtractor.js
+++ b/packages/server/src/ChunkExtractor.js
@@ -1,13 +1,13 @@
 /* eslint-disable react/no-danger */
 import path from 'path'
 import fs from 'fs'
-import uniq from 'lodash/uniq'
-import uniqBy from 'lodash/uniqBy'
-import flatMap from 'lodash/flatMap'
+import uniq from 'lodash/uniq.js'
+import uniqBy from 'lodash/uniqBy.js'
+import flatMap from 'lodash/flatMap.js'
 import React from 'react'
-import { invariant, getRequiredChunkKey } from './sharedInternals'
-import ChunkExtractorManager from './ChunkExtractorManager'
-import { smartRequire, joinURLPath, readJsonFileSync } from './util'
+import { invariant, getRequiredChunkKey } from './sharedInternals.js'
+import ChunkExtractorManager from './ChunkExtractorManager.js'
+import { smartRequire, joinURLPath, readJsonFileSync } from './util.js'
 
 const EXTENSION_SCRIPT_TYPES = {
   '.js': 'script',

--- a/packages/server/src/ChunkExtractor.test.js
+++ b/packages/server/src/ChunkExtractor.test.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import 'regenerator-runtime/runtime'
+import 'regenerator-runtime/runtime.js'
 import path from 'path'
 import stats from '../__fixtures__/stats.json'
-import ChunkExtractor from './ChunkExtractor'
+import ChunkExtractor from './ChunkExtractor.js'
 
 const targetPath = path.resolve(
   __dirname,
@@ -683,7 +683,7 @@ describe('ChunkExtrator', () => {
       expect(extractor.inputFileSystem.readFile).toHaveBeenCalledTimes(2)
       expect(data).toMatchInlineSnapshot(`
         "foo
-        
+
         foo
         "
       `)

--- a/packages/server/src/ChunkExtractorManager.js
+++ b/packages/server/src/ChunkExtractorManager.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Context } from './sharedInternals'
+import { Context } from './sharedInternals.js'
 
 const ChunkExtractorManager = ({ extractor, children }) => (
   <Context.Provider value={extractor}>{children}</Context.Provider>

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -1,2 +1,2 @@
-export { default as ChunkExtractorManager } from './ChunkExtractorManager'
-export { default as ChunkExtractor } from './ChunkExtractor'
+export { default as ChunkExtractorManager } from './ChunkExtractorManager.js'
+export { default as ChunkExtractor } from './ChunkExtractor.js'

--- a/packages/server/src/util.test.js
+++ b/packages/server/src/util.test.js
@@ -1,4 +1,4 @@
-import { joinURLPath } from './util'
+import { joinURLPath } from './util.js'
 
 describe('util', () => {
   describe('#joinURLPath', () => {


### PR DESCRIPTION
## Summary

Brings back extensions removed in 114cea2b61ef644d3b794a9b5f48df69f0f5400b, which caused issue #1005.

## Test plan

Warning! The infra (particularly Webpack 4) did not let me even install the repository, so this is a "blind fix".

Testing should be fairly simple though if someone is able to:

- Build the package
- Open ESM file from dist directory using node (e.g. `node ./dist/esm/loadable-server.esm.mjs`)
- Observe if it doesn't crash upon module resolution