### PR TITLE
Move `initialChunks` store variable to window global variable

### DIFF
--- a/packages/component/.size-snapshot.json
+++ b/packages/component/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/cjs/loadable.cjs.js": {
-    "bundled": 16900,
-    "minified": 7226,
-    "gzipped": 2553
+    "bundled": 17103,
+    "minified": 7356,
+    "gzipped": 2583
   },
   "dist/esm/loadable.esm.mjs": {
-    "bundled": 16517,
-    "minified": 6917,
-    "gzipped": 2490,
+    "bundled": 16720,
+    "minified": 7047,
+    "gzipped": 2520,
     "treeshaked": {
       "rollup": {
         "code": 259,
         "import_statements": 259
       },
       "webpack": {
-        "code": 5764
+        "code": 5858
       }
     }
   }

--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -3,7 +3,7 @@ import React from 'react'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import { invariant } from './util'
 import Context from './Context'
-import { LOADABLE_SHARED } from './shared'
+import { getInitialChunks } from './shared'
 
 const STATUS_PENDING = 'PENDING'
 const STATUS_RESOLVED = 'RESOLVED'
@@ -173,7 +173,7 @@ function createLoadable({
           ((ctor.isReady && ctor.isReady(props)) ||
             // is ready - was loaded during SSR process
             (ctor.chunkName &&
-              LOADABLE_SHARED.initialChunks[ctor.chunkName(props)]))
+              getInitialChunks()[ctor.chunkName(props)]))
         ) {
           this.loadSync()
         }

--- a/packages/component/src/loadableReady.js
+++ b/packages/component/src/loadableReady.js
@@ -2,7 +2,7 @@
 /* eslint-env browser */
 import { warn } from './util'
 import { getRequiredChunkKey } from './sharedInternals'
-import { LOADABLE_SHARED } from './shared'
+import { getInitialChunks } from './shared'
 
 const BROWSER = typeof window !== 'undefined'
 
@@ -26,8 +26,9 @@ export default function loadableReady(
       const extElement = document.getElementById(`${id}_ext`)
       if (extElement) {
         const { namedChunks } = JSON.parse(extElement.textContent)
+        const initialChunks = getInitialChunks()
         namedChunks.forEach(chunkName => {
-          LOADABLE_SHARED.initialChunks[chunkName] = true
+          initialChunks[chunkName] = true
         })
       } else {
         // version mismatch

--- a/packages/component/src/shared.js
+++ b/packages/component/src/shared.js
@@ -1,3 +1,9 @@
-export const LOADABLE_SHARED = {
-  initialChunks: {},
+/* eslint-env browser */
+const INITIAL_CHUNKS_KEY = '__LOADABLE_INITIAL_CHUNKS__'
+
+export function getInitialChunks() {
+  if (!window[INITIAL_CHUNKS_KEY]) {
+    window[INITIAL_CHUNKS_KEY] = {}
+  }
+  return window[INITIAL_CHUNKS_KEY]
 }


### PR DESCRIPTION
## Summary

Supports calling `loadableReady` once, when there are multiple hydration entry points.

### Example:

- main entry:
```js
initSomething()

loadableReady(() => {
  window.dispatchEvent(new CustomEvent('loadable:ready'))
})
```
- app1 entry:
```jsx
window.addEventListener('loadable:ready', () => {
  hydrateRoot(document.getElementById('app-1'), <App1 />)
})
```
- app2 entry:
```jsx
window.addEventListener('loadable:ready', () => {
  hydrateRoot(document.getElementById('app-2'), <App2 />)
})
```

### Note

To make this with the current version, the `namespace` property must be implemented for each entry with the `loadableReady` call, also the required chunks are duplicated for each JSON script when the different apps use the same component.

## Test plan

No changes were applied that modify the current behavior.