### PR TITLE
Update `react` peer dependency ranges to include v19 

### DIFF
--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "yarn run build"
   },
   "peerDependencies": {
-    "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.18",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@loadable/component": "^5.0.1",
-    "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "lodash": "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,7 +803,7 @@
 
 "@babel/runtime@^7.12.18", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.1", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.7.6":
   version "7.24.4"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@babel/runtime/-/runtime-7.24.4.tgz#de795accd698007a66ba44add6cc86542aff1edd"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.4.tgz#de795accd698007a66ba44add6cc86542aff1edd"
   integrity sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==
   dependencies:
     regenerator-runtime "^0.14.0"


### PR DESCRIPTION
## Summary

Resolves #1014.

Appends `^19.0.0` to the `react` peer dependencies in both the `@loadable/component` and `@loadable/server` packages. I don't think there's anything about those package's usage of `react` that would prevent React 19 from being compatible with them.

## Test plan

I struggled for a long time trying to get node v12 installed (via [mise](https://mise.jdx.dev/)) as well as installing deps with `yarn`. Having to install Python 2.x is a pain.

Additionally, I had to replace a reference to what appears to be a private atlassian registry in the lockfile with a reference to the `yarnpkg` registry.

After a while I gave up on node 12 and ran tests with node 16 (node 18 didn't work either) after manually executing parts of the `prepare` script. All tests passed on my machine, though the repo is still using React 16 so the tests aren't really a guarantee that React 19 works. I didn't try updating the react dev deps to 19 for fear of more headaches, but happy to try it out if it's deemed necessary to merge this PR.

Overall this was a very unpleasant contribution experience, though in fairness this repo doesn't exactly have regular contributions so it's understandable.