### PR TITLE
Fix lazy components suspending unnecessarily when already preloaded by loadableReady

### DIFF
--- a/packages/component/src/createLoadable.js
+++ b/packages/component/src/createLoadable.js
@@ -312,7 +312,7 @@ function createLoadable({
         } = this.props
         const { error, loading, result } = this.state
 
-        if (options.suspense) {
+        if (options.suspense && loading) {
           const cachedPromise = this.getCache() || this.loadAsync()
           if (cachedPromise.status === STATUS_PENDING) {
             throw this.loadAsync()


### PR DESCRIPTION
## Summary

Currently, when using `lazy` in combination with SSR (ChunkExtractor on the server side and loadableReady on the client), hydration does not reliably succeed despite the chunks being ready.

This is caused by the suspense branch suspending despite having the module ready and not being in a `loading` state. By using the existing result when state is not `loading`, we can avoid suspending and hydrate reliably without mismatches. 

The existing logic does not work because there is no `cachedPromise` if preloaded via loadableReady

## Test plan

Added two tests that replicate the babel transformed output when using the plugin.

There are lint failures on files unrelated to this PR that exist on main